### PR TITLE
feat: add design rationale and align bias-prevention principles

### DIFF
--- a/.claude/hooks/check-autoflow-gate.sh
+++ b/.claude/hooks/check-autoflow-gate.sh
@@ -23,7 +23,9 @@ set -euo pipefail
 # Configuration
 # ---------------------------------------------------------------------------
 STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.autoflow-state"
-PASS_THRESHOLD=7
+PASS_THRESHOLD="7.5"
+MIN_CATEGORY_SCORE=7
+SECURITY_AUTO_FAIL_THRESHOLD=3
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,44 +67,81 @@ get_current_step() {
 }
 
 # ---------------------------------------------------------------------------
-# Read evaluation score
+# Extract a score value from evaluation JSON
 # ---------------------------------------------------------------------------
-# Expects a file: .autoflow-state/<issue>/evaluation.json
-# Must contain "overall" field with numeric score
-get_evaluation_score() {
-  local issue="$1"
-  local eval_file="${STATE_DIR}/${issue}/evaluation.json"
-  if [[ ! -f "$eval_file" ]]; then
-    echo "0"
-    return
-  fi
-
-  # Extract "overall" score — works with basic JSON
-  local score
-  score=$(grep -o '"overall"[[:space:]]*:[[:space:]]*[0-9.]*' "$eval_file" \
-          | head -1 \
-          | grep -o '[0-9.]*$' || echo "0")
-  echo "$score"
+# Uses basic grep/sed — no jq dependency required
+extract_score() {
+  local file="$1"
+  local key="$2"
+  grep -o "\"${key}\"[[:space:]]*:[[:space:]]*[0-9.]*" "$file" \
+    | head -1 \
+    | grep -o '[0-9.]*$' || echo "0"
 }
 
 # ---------------------------------------------------------------------------
 # Check: Is evaluation passing?
 # ---------------------------------------------------------------------------
+# IMPORTANT: This function does NOT read the AI-generated "pass" field.
+# It calculates pass/fail independently from the raw scores.
+# Reason: AI self-reporting is unreliable — it may implicitly adjust
+# standards while scoring. The gate operates on numbers, not AI judgment.
+# See: docs/design-rationale.md (Decision 3)
 check_evaluation_pass() {
   local issue="$1"
-  local score
-  score=$(get_evaluation_score "$issue")
+  local eval_file="${STATE_DIR}/${issue}/evaluation.json"
 
-  # Compare using awk for float comparison
-  local passed
-  passed=$(awk "BEGIN { print ($score >= $PASS_THRESHOLD) ? 1 : 0 }")
+  if [[ ! -f "$eval_file" ]]; then
+    log_fail "No evaluation file found: ${eval_file}"
+    return 1
+  fi
 
-  if [[ "$passed" -eq 1 ]]; then
-    log_pass "Evaluation score: ${score} (>= ${PASS_THRESHOLD}) — PASS"
+  # Extract individual category scores from the raw "scores" object
+  local correctness code_quality test_coverage security performance
+  correctness=$(extract_score "$eval_file" "correctness")
+  code_quality=$(extract_score "$eval_file" "code_quality")
+  test_coverage=$(extract_score "$eval_file" "test_coverage")
+  security=$(extract_score "$eval_file" "security")
+  performance=$(extract_score "$eval_file" "performance")
+
+  log_info "Scores — correctness:${correctness} code_quality:${code_quality} test_coverage:${test_coverage} security:${security} performance:${performance}"
+
+  # Calculate weighted average from raw scores (NOT using AI's "overall" field)
+  local calculated_overall
+  calculated_overall=$(awk "BEGIN { printf \"%.2f\", ($correctness * 0.30) + ($code_quality * 0.20) + ($test_coverage * 0.20) + ($security * 0.15) + ($performance * 0.15) }")
+
+  log_info "Calculated overall: ${calculated_overall} (threshold: ${PASS_THRESHOLD})"
+
+  # Check 1: Security auto-fail
+  local security_fail
+  security_fail=$(awk "BEGIN { print ($security <= $SECURITY_AUTO_FAIL_THRESHOLD) ? 1 : 0 }")
+  if [[ "$security_fail" -eq 1 ]]; then
+    log_fail "Security score: ${security} (<= ${SECURITY_AUTO_FAIL_THRESHOLD}) — AUTO-FAIL (mandatory rework)"
+    return 1
+  fi
+
+  # Check 2: Individual category minimums
+  local min_fail
+  min_fail=$(awk "BEGIN {
+    min = $correctness
+    if ($code_quality < min) min = $code_quality
+    if ($test_coverage < min) min = $test_coverage
+    if ($security < min) min = $security
+    if ($performance < min) min = $performance
+    print (min < $MIN_CATEGORY_SCORE) ? 1 : 0
+  }")
+  if [[ "$min_fail" -eq 1 ]]; then
+    log_fail "One or more categories below minimum (${MIN_CATEGORY_SCORE}) — FAIL"
+    return 1
+  fi
+
+  # Check 3: Overall weighted average
+  local overall_pass
+  overall_pass=$(awk "BEGIN { print ($calculated_overall >= $PASS_THRESHOLD) ? 1 : 0 }")
+  if [[ "$overall_pass" -eq 1 ]]; then
+    log_pass "Evaluation: ${calculated_overall} (>= ${PASS_THRESHOLD}), all categories >= ${MIN_CATEGORY_SCORE} — PASS"
     return 0
   else
-    log_fail "Evaluation score: ${score} (< ${PASS_THRESHOLD}) — FAIL"
-    log_info "Return to STEP 3 and address evaluation feedback before proceeding."
+    log_fail "Overall score: ${calculated_overall} (< ${PASS_THRESHOLD}) — FAIL"
     return 1
   fi
 }

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -3,6 +3,9 @@
 > This file is the single source of truth for how Claude Code operates in this project.
 > It defines the Auto-Flow lifecycle, evaluation gates, agent roles, and operational rules.
 
+**New AI agents: Read [docs/design-rationale.md](docs/design-rationale.md) FIRST.**
+It explains _why_ every rule exists. Understanding the design intent takes priority over following the rules. Without understanding the reasons, you may propose changes that look better but undermine core principles.
+
 ---
 
 ## Table of Contents
@@ -50,22 +53,25 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 | STEP | Name | Description | Exit Criteria |
 |------|------|-------------|---------------|
 | 0 | **Issue Analysis** | Understand the issue/request thoroughly | Issue requirements documented |
-| 1 | **3-Phase Analysis** | Independent structure analysis (bias prevention) | 3 independent analyses completed |
+| 1 | **3-Phase Analysis** | Information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
+| 1.5 | **Issue Analysis Eval** | Gate: is the analysis sufficient? | Score >= 7.5 or issue closed |
 | 2 | **Plan Synthesis** | Merge analyses into implementation plan | Plan approved |
 | 3 | **Implementation** | Write the code | Code compiles, basic functionality works |
 | 4 | **Self-Review** | Developer AI reviews own code | No obvious issues found |
 | 5 | **Test** | Test AI writes and runs tests | All tests pass |
-| 6 | **Evaluation** | Evaluation AI scores the work | Score >= 7 (PASS) |
+| 6 | **Evaluation** | Fresh-spawned Evaluation AI scores the work | Score >= 7.5 (PASS) |
 | 7 | **Revision** | Fix issues from evaluation (if needed) | Re-evaluation PASS |
 | 8 | **PR & Review** | Create PR for human review | PR submitted |
 | 9 | **Merge & Close** | Merge after human approval | Issue closed |
 
 ### Execution Principles
 
-1. **Never skip steps.** Each STEP builds on the previous one.
-2. **Regression is allowed.** If STEP 6 fails, return to STEP 3 and redo.
-3. **Human gates exist.** STEP 8→9 always requires human approval.
-4. **State is tracked.** Use `.autoflow-state/` files to persist STEP status.
+1. **Never skip steps.** Each STEP builds on the previous one — regardless of change size. "This one is simple" is itself a biased judgment.
+2. **Regression is allowed.** If STEP 6 fails, return to STEP 7 (or STEP 3 for major issues).
+3. **STEP 1.5 FAIL = issue close.** If existing structure handles the concern, no code change is needed.
+4. **Human gates exist.** STEP 8→9 always requires human approval.
+5. **State is tracked.** Use `.autoflow-state/` files to persist STEP status.
+6. **Pipeline is stateless.** Past issue evaluations do not influence current analysis. Improvement happens outside the pipeline, through human-driven CLAUDE.md updates.
 
 ---
 
@@ -74,13 +80,16 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 | Current State | Condition | Next State |
 |--------------|-----------|------------|
 | STEP 0 | Issue analyzed | → STEP 1 |
-| STEP 1 | 3 analyses done | → STEP 2 |
+| STEP 1 | 3 isolated analyses done | → STEP 1.5 |
+| STEP 1.5 (score >= 7.5) | PASS | → STEP 2 |
+| STEP 1.5 (FAIL) | Existing structure sufficient | → **Issue closed** |
 | STEP 2 | Plan approved | → STEP 3 |
 | STEP 3 | Code complete | → STEP 4 |
 | STEP 4 | Self-review clean | → STEP 5 |
 | STEP 5 | Tests pass | → STEP 6 |
-| STEP 6 (score >= 7) | PASS | → STEP 8 |
-| STEP 6 (score < 7) | FAIL | → STEP 3 (redo) |
+| STEP 6 (score >= 7.5, all categories >= 7) | PASS | → STEP 8 |
+| STEP 6 (score < 7.5 or category < 7) | FAIL | → STEP 7 |
+| STEP 6 (security <= 3) | AUTO-FAIL | → STEP 3 (major rework) |
 | STEP 7 | Re-eval PASS | → STEP 8 |
 | STEP 8 | PR submitted | → STEP 9 (human) |
 | STEP 9 | Merged | → Done |
@@ -108,8 +117,9 @@ Auto-Flow uses **multi-agent role separation** to prevent single-point-of-failur
 
 ### Evaluation AI
 - **Scope**: Read-only across relevant repos
-- **Responsibilities**: Score the work using the 10-point scale (STEP 6)
+- **Responsibilities**: Score the work using the 10-point scale (STEPs 1.5, 6)
 - **Cannot**: Fix code — only report issues
+- **Critical**: Must be **spawned fresh** for every evaluation. Never reuse an evaluation agent — self-reinforcement bias makes prior investment in reasoning influence the judgment. See [docs/design-rationale.md](docs/design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
 
 ### Communication Between Agents
 
@@ -126,27 +136,33 @@ Evaluation AI → Orchestrator: "Score: 8/10 — PASS"
 
 ---
 
-## 3-Phase Independent Analysis
+## 3-Phase Independent Analysis (Information Isolation)
 
-To prevent tunnel-vision bias, STEP 1 runs **three independent analyses** before any coding begins.
+> **Why information isolation?** See [docs/design-rationale.md](docs/design-rationale.md#decision-1-ai-a-does-not-receive-the-issue-content-3-phase-independent-analysis)
 
-### Phase A: Top-Down Analysis
-- Start from high-level architecture
-- Identify affected components and their relationships
-- Map the change impact across the system
+To prevent tunnel-vision bias, STEP 1 uses **information isolation** — not just different perspectives, but strictly separated inputs.
 
-### Phase B: Bottom-Up Analysis
-- Start from the specific code that needs to change
-- Trace dependencies upward
-- Identify edge cases and constraints
+### Phase A: Structure Analysis (AI-A) — DOES NOT SEE THE ISSUE
+- **AI-A receives only the codebase.** It never sees the issue text.
+- Analyze current architecture, patterns, and component relationships
+- Document structural facts — what exists, how it works, what its constraints are
+- This prevents the "looking for structure that solves the problem" bias
 
-### Phase C: Lateral Analysis
-- Look at similar features/patterns already in the codebase
-- Check for existing utilities, patterns, or conventions to reuse
-- Identify potential conflicts with parallel work
+### Phase B: Issue Analysis (AI-B) — DOES NOT SEE THE CODE
+- **AI-B receives only the issue text.** It does not access the codebase.
+- Analyze the problem, requirements, and constraints from the issue alone
+- Propose potential resolution approaches
+- It is normal for AI-B to use zero tools
+
+### Phase 3: Cross-Verification
+- AI-A evaluates AI-B's proposals from a structural perspective
+- Determines if existing structure already handles the concern
+- Identifies structural feasibility of proposed approaches
 
 ### Synthesis (STEP 2)
 Merge all three analyses into a single implementation plan. Conflicts between phases must be explicitly resolved with rationale.
+
+**Do NOT give AI-A the issue content "for efficiency."** This destroys the core mechanism. See design rationale.
 
 ---
 
@@ -165,8 +181,9 @@ Merge all three analyses into a single implementation plan. Conflicts between ph
 | 1–2 | Failing — does not meet requirements |
 
 ### PASS Criteria
-- **Overall score >= 7** to proceed to STEP 8
-- **No individual category below 5**
+- **Overall weighted score >= 7.5** to proceed to STEP 8
+- **No individual category below 7**
+- **Security score <= 3 → automatic FAIL** (mandatory rework, cannot be diluted by averaging)
 
 ### Evaluation Categories
 
@@ -234,9 +251,12 @@ When ambiguity or disagreement arises during any STEP, follow this protocol:
 The Auto-Flow Hook (`check-autoflow-gate.sh`) enforces STEP progression:
 
 - **Trigger**: Runs before commit or PR creation
-- **Checks**: Validates that the current STEP's exit criteria are met
-- **Blocks**: Prevents advancing if evaluation hasn't passed
+- **Checks**: Calculates scores directly from raw `scores` in evaluation JSON
+- **Does NOT trust**: The AI-generated `pass` field — it computes pass/fail independently from the numbers
+- **Blocks**: Prevents advancing if calculated scores don't meet thresholds
 - **State files**: Stored in `.autoflow-state/` directory
+
+> **Why distrust the `pass` field?** AI tends to implicitly adjust standards while scoring. The hook ignores AI judgment and checks only the numbers. See [docs/design-rationale.md](docs/design-rationale.md#decision-3-the-hook-does-not-trust-ais-pass-judgment).
 
 Configuration: See [.claude/hooks/check-autoflow-gate.sh](.claude/hooks/check-autoflow-gate.sh)
 
@@ -292,7 +312,7 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
 ### PR Requirements
 
 - [ ] All tests pass
-- [ ] Evaluation score >= 7 (PASS)
+- [ ] Evaluation score >= 7.5 (PASS), no category below 7
 - [ ] No security checklist violations
 - [ ] PR description includes issue reference
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Templates use `{{UPPER_SNAKE_CASE}}` placeholders:
 
 | Document | Description |
 |----------|-------------|
+| [**Design Rationale**](docs/design-rationale.md) | **Read first** — why every design decision was made |
 | [Auto-Flow Guide](docs/autoflow-guide.md) | Detailed step-by-step lifecycle |
 | [Evaluation System](docs/evaluation-system.md) | Scoring, PASS criteria, output format |
 | [Git Workflow](docs/git-workflow.md) | Branch naming, commits, PR process |

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -36,32 +36,70 @@ The key principles:
 
 ---
 
-## STEP 1: 3-Phase Independent Analysis
+## STEP 1: 3-Phase Independent Analysis (Information Isolation)
 
-**Goal**: Prevent tunnel-vision bias by analyzing the problem from three independent perspectives.
+**Goal**: Prevent tunnel-vision bias through **information isolation** — not just different perspectives, but strictly separated inputs.
 
-### Phase A: Top-Down Analysis
-Start from the system architecture and work downward:
-- Which components are affected?
-- What are the data flow implications?
-- Are there cross-service impacts?
+> **Design rationale**: AI is biased toward solving the moment it receives an issue. If the structure-analyzing AI knows the issue, it starts looking for "structure that solves this problem" instead of seeing structure as it is. Information asymmetry is what makes cross-verification valid. See [docs/design-rationale.md](design-rationale.md) for full reasoning.
 
-### Phase B: Bottom-Up Analysis
-Start from the specific code and work upward:
-- Which files/functions need to change?
-- What are the direct dependencies?
-- What edge cases exist at the code level?
+### Phase A: Structure Analysis (AI-A) — NO ISSUE CONTENT
 
-### Phase C: Lateral Analysis
-Look sideways at the existing codebase:
-- Are there similar features already implemented?
-- What patterns/conventions should be followed?
-- Are there shared utilities to reuse?
+**AI-A receives the codebase only. It does NOT receive the issue text.**
+
+- Analyze the current code structure, architecture, and patterns
+- Document how components relate and interact
+- Identify structural strengths, weaknesses, and constraints
+- Report factual findings about what exists
+
+**Critical rule**: AI-A must never see the issue content. This is not optional. Giving AI-A the issue "for efficiency" destroys the core mechanism of this system.
+
+### Phase B: Issue Analysis (AI-B) — NO CODE ACCESS
+
+**AI-B receives the issue text only. It does NOT access the codebase.**
+
+- Analyze the problem described in the issue
+- Identify requirements, constraints, and acceptance criteria
+- Propose potential resolution approaches based on the issue text alone
+- It is normal for AI-B to use zero tools — analyzing only the issue text is its purpose
+
+**Critical rule**: AI-B must not read code. If it reads code, it shares the same bias as AI-A, making Phase 3 verification purely ceremonial.
+
+### Phase 3: Cross-Verification
+
+**AI-A evaluates AI-B's proposed resolution from a structural perspective.**
+
+- Does the existing structure already handle what the issue describes?
+- Are AI-B's proposed approaches structurally sound?
+- What are the actual code-level implications of each approach?
+- Are there conflicts between what the issue asks for and what the structure supports?
 
 ### Exit Criteria
-- All three analyses documented
-- Key findings from each phase recorded
+- Phase A analysis documented (structure only, no issue awareness)
+- Phase B analysis documented (issue only, no code access)
+- Phase 3 cross-verification documented
 - Conflicts between phases identified
+
+---
+
+## STEP 1.5: Issue Analysis Evaluation (Gate)
+
+**Goal**: Ensure only well-analyzed issues proceed to implementation. This gate is strict because insufficient analysis at this stage causes larger costs downstream.
+
+> **The Evaluation AI is spawned fresh** for this step — it carries no prior conversation history. This prevents self-reinforcement bias.
+
+### Process
+1. A freshly spawned Evaluation AI receives: Phase A report, Phase B report, Phase 3 cross-verification
+2. Evaluates whether the analysis is thorough enough for implementation planning
+3. Produces a scored evaluation
+
+### PASS / FAIL
+- **PASS** (score >= 7.5): Proceed to STEP 2
+- **FAIL**: **Close the issue.** If the structure already handles the concern, no code change is needed. This is not a regression — it is the system working correctly. The best code is code that is never written.
+
+### Exit Criteria
+- Evaluation report saved
+- PASS → proceed to STEP 2
+- FAIL → issue closed (existing structure sufficient)
 
 ---
 
@@ -165,8 +203,10 @@ Look sideways at the existing codebase:
 
 **Goal**: An independent Evaluation AI scores the work objectively.
 
+> **The Evaluation AI is spawned fresh** for every evaluation — it carries no prior conversation history. This is mandatory. Reusing an evaluation agent creates self-reinforcement bias. See [docs/design-rationale.md](design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
+
 ### Process
-1. Evaluation AI receives: issue requirements, implementation plan, code diff, test results
+1. A **freshly spawned** Evaluation AI receives: issue requirements, implementation plan, code diff, test results
 2. Scores across 5 categories (see Evaluation System)
 3. Produces a JSON evaluation report
 
@@ -181,8 +221,9 @@ Look sideways at the existing codebase:
 | Performance | 15% | No regressions, reasonable efficiency? |
 
 ### PASS / FAIL
-- **PASS**: Overall score >= 7, no category below 5 → proceed to STEP 8
-- **FAIL**: Overall score < 7 or any category below 5 → return to STEP 3
+- **PASS**: Overall weighted score >= 7.5 AND no individual category below 7 → proceed to STEP 8
+- **FAIL**: Overall score < 7.5 OR any category below 7 → return to STEP 7 (or STEP 3 for major issues)
+- **AUTO-FAIL**: Security score <= 3 → mandatory rework regardless of other scores
 
 ### Exit Criteria
 - Evaluation report saved to `.autoflow-state/<issue>/evaluation.json`
@@ -249,15 +290,16 @@ Look sideways at the existing codebase:
 
 ## Regression Rules
 
-When a STEP fails, the flow regresses to an earlier STEP:
+When a STEP fails, the flow regresses — or terminates:
 
-| Failure Point | Regress To | Reason |
-|--------------|-----------|--------|
-| STEP 5 (tests fail) | STEP 3 | Fix implementation |
-| STEP 6 (eval < 7) | STEP 3 | Significant rework needed |
-| STEP 6 (eval 5-6) | STEP 7 | Minor revisions needed |
-| STEP 8 (CI fails) | STEP 5 | Re-test |
-| STEP 9 (human rejects) | STEP 7 | Address human feedback |
+| Failure Point | Action | Reason |
+|--------------|--------|--------|
+| STEP 1.5 (structure eval FAIL) | **Close issue** | Existing structure already handles it |
+| STEP 5 (tests fail) | → STEP 3 | Fix implementation |
+| STEP 6 (score < 7.5) | → STEP 7 | Revision needed |
+| STEP 6 (security <= 3) | → STEP 3 | Mandatory major rework |
+| STEP 8 (CI fails) | → STEP 5 | Re-test |
+| STEP 9 (human rejects) | → STEP 7 | Address human feedback |
 
 ---
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -1,0 +1,184 @@
+# Auto-Flow Design Rationale
+
+This document explains the design intent and reasoning behind every major decision in Auto-Flow.
+Where CLAUDE.md describes **what to do and how**, this document explains **why** it was designed that way.
+
+**Any new AI reading this repository should read this document first.**
+Understanding the design intent takes priority over following the rules.
+Without understanding the reasons, an AI may propose something that "looks better" but undermines a core principle.
+
+---
+
+## The Problems This System Solves
+
+Auto-Flow addresses structural problems that arise in AI-driven development environments.
+
+### Problem 1: AI Is Biased Toward Solving the Moment It Receives an Issue
+
+AI is trained to be helpful. The moment it receives an issue, the frame "this is a problem to solve" locks into its context. Even when analyzing code afterward, it tends to overlook parts where the existing structure already handles the concern, or proposes unnecessary code changes.
+
+This is not a defect in AI. It is a byproduct of "be helpful" training. It cannot be fixed through training alone. **It must be blocked structurally.**
+
+### Problem 2: A Single Session Cannot Effectively Challenge Its Own Reasoning
+
+When analysis and evaluation happen in the same conversation, previously generated text influences subsequent generation (self-reinforcement). Evaluation converges toward "my analysis was correct." This is a structural problem inherent to the context window.
+
+### Problem 3: AI Self-Reporting Is Unreliable
+
+Even when an AI declares "PASS," whether that judgment actually meets the defined criteria is a separate question. AI tends to implicitly adjust standards while scoring, or interpret edge cases favorably.
+
+---
+
+## Core Design Decisions and Their Reasoning
+
+### Decision 1: AI-A Does Not Receive the Issue Content (3-Phase Independent Analysis)
+
+**What it does**
+
+- **AI-A**: Analyzes code structure only — without seeing the issue content
+- **AI-B**: Analyzes the issue text only — without seeing the code
+- **Phase 3**: AI-A evaluates AI-B's proposed resolution from a structural perspective
+
+**Why it works this way**
+
+Information isolation is the key. If AI-A knows the issue, it starts looking for "structure that solves this problem." Without the issue, it sees the structure as it actually is. The information asymmetry between the two AIs creates the validity of cross-verification.
+
+It is normal for AI-B to use zero tools. Its purpose is to analyze the problem from the issue text alone. If it reads code, it shares the same bias as AI-A, making Phase 3 verification purely ceremonial.
+
+**Why this design must not be changed**
+
+The suggestion "let's give AI-A the issue for efficiency" destroys the core of this system. Bias prevention can only be achieved through information isolation. Claude's built-in bias mitigation training is effective at balancing response tone, but it cannot prevent context contamination.
+
+---
+
+### Decision 2: Evaluation AI Is Spawned Fresh Every Time
+
+**What it does**
+
+The Evaluation AI at STEPs 1.5, 3, 5.7, and 6 is created new for each invocation. It carries no prior conversation history.
+
+**Why it works this way**
+
+To start from a state with no trace of prior reasoning. When the same agent creates a plan and then evaluates it, it struggles to reject its own plan. A freshly spawned agent sees only the deliverable. It has no investment in the process.
+
+**Bias elimination takes priority over cost**
+
+"Reusing the same agent saves tokens" is factually true. But in this system, bias elimination takes priority over cost optimization. The quality of an expert system comes from the independence of its judgments.
+
+---
+
+### Decision 3: The Hook Does Not Trust AI's PASS Judgment
+
+**What it does**
+
+`check-autoflow-gate.sh` does **not** read the `pass` field written by the AI. It calculates the average, minimum, and security score directly from the raw `scores` object.
+
+**Why it works this way**
+
+To bring the trust chain down to the script level. An AI can implicitly decide "this is good enough to pass" while recording scores. The script ignores that judgment and looks only at the numbers. Numbers cannot be manipulated (within the system's constraints).
+
+**What this means**
+
+No matter how eloquently an AI says "the plan is excellent," if the scores don't meet the threshold, it cannot advance to the next step. The gate operates on numbers, not explanations.
+
+---
+
+### Decision 4: The Pipeline Is Designed to Be Stateless
+
+**What it does**
+
+Each issue is processed independently. Past issue evaluation results do not influence the current issue's analysis.
+
+**Why it works this way**
+
+If a past evaluation was wrong and it influences the next evaluation, bias propagates. As incorrect judgments accumulate, the system hardens in a particular direction. Injecting past data into a pipeline whose principle is bias elimination undermines that principle.
+
+**Improvement loops happen outside the pipeline**
+
+Analysis of pass/fail patterns, modification of evaluation criteria, and identification of cross-issue correlations are performed by humans externally. Changes are reflected through CLAUDE.md and evaluation prompt modifications, with history tracked in Git. If the pipeline modifies its own criteria, it becomes impossible to trace which point in time had the correct judgment.
+
+**However, factual lookups are different**
+
+Injecting past evaluation results (bias injection) and looking up past code change history or issue context (factual lookup) are different things. Querying related issues and commit history at STEP 1 is allowed because it serves to accurately understand the current state.
+
+---
+
+### Decision 5: STEP Transitions Are Completion-Condition Based
+
+**What it does**
+
+Each STEP transitions to the next only when its stated completion conditions are met. All STEPs are performed regardless of change size.
+
+**Why it works this way**
+
+AI tends to judge "this change is small enough to skip STEPs." That judgment itself is a product of bias. The thought "this one is simple" causes verification to be skipped, and problems emerge from the skipped verification. Simplicity can be determined after the process, not before it.
+
+---
+
+### Decision 6: Structure Evaluation FAIL Means Issue Close
+
+**What it does**
+
+When the structure evaluation at STEPs 1–2 returns FAIL, Auto-Flow terminates and the issue is closed. It means the existing structure can already handle the concern — no code change needed.
+
+**Why it works this way**
+
+The best code is code that is never written. AI feels pressure to create something when it receives an issue. Structure evaluation is the first gate that blocks that pressure. In practice, this judgment has prevented unnecessary code changes — when existing architecture already solved the problem.
+
+---
+
+## Evaluation System Design Intent
+
+### Why Scoring Criteria Are Not Fixed
+
+The evaluation categories and weights in CLAUDE.md must be customized per project. They should reflect "what actually matters in this project," not universal standards. As a project matures, patterns emerge showing which items correlate with actual failures. At that point, humans adjust the criteria.
+
+### Why PASS Criteria Are Strict (Average >= 7.5, Individual >= 7)
+
+Lenient criteria create a pattern of "scoring high on easy items to raise the average while passing difficult items." This is why individual minimum thresholds exist. The reason security score <= 3 triggers mandatory rework is the same — some items cannot be diluted by averaging.
+
+### The Role of Issue Analysis Evaluation (STEP 1.5)
+
+The purpose is to ensure only well-analyzed issues proceed to implementation. Entering implementation with insufficient analysis incurs greater costs later. The stricter this gate, the higher the quality of subsequent STEPs.
+
+---
+
+## What Must NOT Be Done in This System
+
+The following may look like "better approaches" but undermine core principles:
+
+| Do Not | Reason |
+|--------|--------|
+| Give AI-A the issue content | Context contamination → bias introduced |
+| Reuse the Evaluation AI | Self-reinforcement bias → independence lost |
+| Trust the Hook's `pass` field | Trusting AI self-report → gate neutralized |
+| Inject past evaluation results into current analysis | Bias propagation → system hardens in one direction |
+| Allow STEP-skipping judgment | "This one is simple" is itself a biased judgment |
+| Let the pipeline modify its own criteria | Judgment tracing impossible → trust chain collapse |
+
+---
+
+## Known Limitations and Ongoing Discussions
+
+### Limitations
+
+- **No failure learning loop**: Currently accumulated manually via issue comments. Pass/fail pattern analysis is performed by humans externally.
+- **No cross-issue correlation detection**: Cannot automatically detect repeated similar-pattern issues. Under internal discussion.
+- **No lightweight mode**: Full STEP execution even for small changes. Overhead exists.
+
+### Under Discussion
+
+- Including related issue and commit history lookup at STEP 1 entry (factual lookup, not bias injection)
+- Systematizing issue preparation stages through external cross-issue correlation analysis
+
+---
+
+## Summary: The Design Philosophy of This System
+
+**The pipeline's goal is not to get better with each run, but to perform well without bias every single time.**
+
+Improvement does not happen automatically inside the pipeline. Humans observe patterns, make judgments, modify CLAUDE.md, and those changes take effect from the next issue onward. The pipeline is a tool that executes those criteria without bias.
+
+When adding new features or modifications to this system, ask this question first:
+
+> "Does this change eliminate a bias, or does it introduce one?"

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -1,12 +1,18 @@
 # Evaluation System
 
-> The Auto-Flow evaluation system provides quantified quality assessment at STEP 6, ensuring consistent standards across all changes.
+> The Auto-Flow evaluation system provides quantified quality assessment at STEPs 1.5 and 6, ensuring consistent standards across all changes.
 
 ---
 
 ## Overview
 
 The Evaluation AI is an **independent agent** that scores completed work before it reaches human review. This separation ensures objectivity — the agent that wrote the code never evaluates it.
+
+### Critical Rule: Fresh Spawn Every Time
+
+**The Evaluation AI must be spawned fresh for every evaluation** — at STEPs 1.5, 3, 5.7, and 6. It carries no prior conversation history. This is mandatory, not optional.
+
+**Why**: When the same agent creates a plan and evaluates it, it struggles to reject its own work. A freshly spawned agent sees only the deliverable — it has no investment in the process. Bias elimination takes priority over token cost savings. See [docs/design-rationale.md](design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
 
 ---
 
@@ -29,12 +35,25 @@ The Evaluation AI is an **independent agent** that scores completed work before 
 
 ## PASS Criteria
 
-A change **passes** evaluation when:
+A change **passes** evaluation when ALL of the following are true:
 
-1. **Overall weighted score >= 7**
-2. **No individual category scores below 5**
+1. **Overall weighted score >= 7.5**
+2. **No individual category score below 7**
+3. **Security score is NOT <= 3** (auto-fail trigger)
 
-If either condition is not met, the change **fails** and must be revised (STEP 7).
+If any condition is not met, the change **fails**.
+
+### Why These Thresholds Are Strict
+
+Lenient criteria create a pattern of "scoring high on easy categories to raise the average while passing weak categories." The individual minimum threshold (>= 7) prevents this gaming. Security <= 3 triggers mandatory rework because security cannot be diluted by averaging — some items are non-negotiable.
+
+### Auto-FAIL Rules
+
+| Condition | Result | Action |
+|-----------|--------|--------|
+| Security <= 3 | AUTO-FAIL | → STEP 3 (mandatory major rework) |
+| Any category < 7 | FAIL | → STEP 7 (revision) |
+| Overall < 7.5 | FAIL | → STEP 7 (revision) |
 
 ---
 
@@ -59,12 +78,22 @@ overall = (correctness * 0.30) + (code_quality * 0.20) + (test_coverage * 0.20)
 
 ```
 correctness:    8 * 0.30 = 2.40
-code_quality:   7 * 0.20 = 1.40
+code_quality:   8 * 0.20 = 1.60
 test_coverage:  7 * 0.20 = 1.40
 security:       9 * 0.15 = 1.35
 performance:    7 * 0.15 = 1.05
                          ------
-overall:                   7.60  → PASS
+overall:                   7.80  → PASS (>= 7.5, all categories >= 7)
+```
+
+```
+correctness:    9 * 0.30 = 2.70
+code_quality:   8 * 0.20 = 1.60
+test_coverage:  6 * 0.20 = 1.20    ← below 7!
+security:       8 * 0.15 = 1.20
+performance:    8 * 0.15 = 1.20
+                         ------
+overall:                   7.90  → FAIL (test_coverage 6 < minimum 7)
 ```
 
 ---
@@ -150,10 +179,12 @@ The Evaluation AI receives:
 
 When a change fails and goes through STEP 7 (revision):
 
-1. The Evaluation AI receives the **updated** diff and test results
+1. A **freshly spawned** Evaluation AI receives the **updated** diff and test results
 2. It also receives the **previous evaluation** for context
 3. It re-evaluates from scratch (not incrementally)
 4. The new evaluation replaces the old one in the state file
+
+> The re-evaluation AI is also spawned fresh — never reused from the previous evaluation cycle.
 
 ### Maximum Revision Cycles
 
@@ -165,11 +196,14 @@ When a change fails and goes through STEP 7 (revision):
 
 ## Hook Integration
 
-The `check-autoflow-gate.sh` hook reads the evaluation JSON to enforce the gate:
+The `check-autoflow-gate.sh` hook enforces the gate by **calculating pass/fail independently from raw scores**:
 
-- At **STEP 6**: Checks if `evaluation.json` exists and `pass === true`
-- At **STEP 8**: Re-verifies that the evaluation still passes before allowing PR creation
-- The hook uses the `overall` score and `PASS_THRESHOLD` (default: 7)
+- The hook **does NOT read the AI-generated `pass` field**
+- It extracts individual scores from the `scores` object and calculates the weighted average itself
+- It checks: weighted average >= 7.5, all categories >= 7, security > 3
+- This design brings the trust chain down to the script level — AI judgment is bypassed
+
+> **Why?** AI tends to implicitly adjust standards while scoring, or interpret edge cases favorably. The hook ignores AI judgment and checks only numbers. See [docs/design-rationale.md](design-rationale.md#decision-3-the-hook-does-not-trust-ais-pass-judgment).
 
 ---
 
@@ -183,8 +217,8 @@ Modify the category weights in `CLAUDE.md` to match your project priorities:
 
 ### Adjusting PASS Threshold
 
-The default threshold is 7. To change:
-1. Update `PASS_THRESHOLD` in `check-autoflow-gate.sh`
+The default thresholds are: overall >= 7.5, individual >= 7, security auto-fail <= 3. To change:
+1. Update `PASS_THRESHOLD`, `MIN_CATEGORY_SCORE`, and `SECURITY_AUTO_FAIL_THRESHOLD` in `check-autoflow-gate.sh`
 2. Update the PASS criteria in `CLAUDE.md`
 3. Document the change and rationale
 


### PR DESCRIPTION
## Summary

- Add `docs/design-rationale.md` — English translation of the Auto-Flow design philosophy document explaining **why** every decision was made (mandatory first-read for new AI agents)
- Rewrite 3-Phase analysis from perspective-based to **information-isolated**: AI-A sees code only (no issue), AI-B sees issue only (no code)
- Add **STEP 1.5** evaluation gate: FAIL = issue close (existing structure sufficient, no code change needed)
- Tighten PASS criteria: overall >= 7.5, individual >= 7, security <= 3 auto-fail
- Rewrite hook to calculate pass/fail from **raw scores directly**, ignoring AI's self-reported `pass` field
- Require **fresh-spawned** Evaluation AI for every evaluation (no agent reuse)

## Key Design Principles Reflected

| Principle | Implementation |
|-----------|---------------|
| Information isolation prevents bias | AI-A and AI-B have strictly separated inputs |
| AI self-reporting is unreliable | Hook calculates from raw scores, ignores `pass` field |
| Fresh spawn prevents self-reinforcement | Evaluation AI created new each time |
| Pipeline is stateless | Past evaluations don't influence current analysis |
| No STEP skipping | All STEPs executed regardless of change size |

## Files Changed

- **New**: `docs/design-rationale.md`
- **Modified**: `CLAUDE.md.template`, `docs/autoflow-guide.md`, `docs/evaluation-system.md`, `.claude/hooks/check-autoflow-gate.sh`, `README.md`

## Test plan

- [ ] Verify `check-autoflow-gate.sh` calculates weighted average correctly from raw scores
- [ ] Verify security <= 3 triggers auto-fail even when overall average is high
- [ ] Verify individual category < 7 triggers fail even when overall >= 7.5
- [ ] Confirm STEP 1.5 is properly documented in flow control table and autoflow guide
- [ ] Confirm design-rationale.md is referenced as first-read in CLAUDE.md.template

https://claude.ai/code/session_01HbwFn6EnGQVtSzWoDkVw15