### PR TITLE
feat(#4): restore TDD cycle (STEP 5a/5b/5c/5d) in template and docs

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -56,9 +56,12 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 | 1 | **3-Phase Analysis** | Information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
 | 1.5 | **Issue Analysis Eval** | Gate: is the analysis sufficient? | Score >= 7.5 or issue closed |
 | 2 | **Plan Synthesis** | Merge analyses into implementation plan | Plan approved |
-| 3 | **Implementation** | Write the code | Code compiles, basic functionality works |
-| 4 | **Self-Review** | Developer AI reviews own code | No obvious issues found |
-| 5 | **Test** | Test AI writes and runs tests | All tests pass |
+| 3 | **Plan Evaluation** | Fresh Evaluation AI scores the plan | Score >= 7.5, all >= 7 |
+| 4 | **Task Assignment** | Delegate to Test AI and Developer AI | Tasks assigned to teammates |
+| 5a | **Test Writing** | Test AI writes tests from acceptance criteria | Tests written, all Red |
+| 5b | **Implementation** | Developer AI writes minimum code to pass tests | Minimum implementation done |
+| 5c | **Green Verification** | All tests pass + minimal implementation check | All Green |
+| 5d | **Refactor** | Code cleanup, Green re-confirmation | Refactor done, Green maintained |
 | 6 | **Evaluation** | Fresh-spawned Evaluation AI scores the work | Score >= 7.5 (PASS) |
 | 7 | **Revision** | Fix issues from evaluation (if needed) | Re-evaluation PASS |
 | 8 | **PR & Review** | Create PR for human review | PR submitted |
@@ -84,9 +87,16 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 | STEP 1.5 (score >= 7.5) | PASS | → STEP 2 |
 | STEP 1.5 (FAIL) | Existing structure sufficient | → **Issue closed** |
 | STEP 2 | Plan approved | → STEP 3 |
-| STEP 3 | Code complete | → STEP 4 |
-| STEP 4 | Self-review clean | → STEP 5 |
-| STEP 5 | Tests pass | → STEP 6 |
+| STEP 3 PASS | Score >= 7.5, all >= 7 | → STEP 4 |
+| STEP 3 FAIL | Below threshold | → STEP 2 (max 3x) |
+| STEP 4 | Tasks assigned to teammates | → STEP 5a |
+| STEP 5a | Tests written, all Red | → STEP 5b |
+| STEP 5b | Minimum implementation done | → STEP 5c |
+| STEP 5c PASS | All Green + minimal impl check | → STEP 5d |
+| STEP 5c FAIL (test issue) | Test incorrect | → STEP 5a (fix test → re-Red) |
+| STEP 5c FAIL (impl issue) | Implementation incorrect | → STEP 5b (fix impl) |
+| STEP 5c DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
+| STEP 5d | Refactor done, Green maintained | → STEP 6 |
 | STEP 6 (score >= 7.5, all categories >= 7) | PASS | → STEP 8 |
 | STEP 6 (score < 7.5 or category < 7) | FAIL | → STEP 7 |
 | STEP 6 (security <= 3) | AUTO-FAIL | → STEP 3 (major rework) |
@@ -107,12 +117,12 @@ Auto-Flow uses **multi-agent role separation** to prevent single-point-of-failur
 
 ### Developer AI
 - **Scope**: Assigned sub-repo only
-- **Responsibilities**: Implementation (STEP 3), self-review (STEP 4)
+- **Responsibilities**: Implementation (STEP 5b), refactor (STEP 5d)
 - **Cannot**: Evaluate own work (STEP 6)
 
 ### Test AI
 - **Scope**: Assigned sub-repo only
-- **Responsibilities**: Write tests, run test suites (STEP 5)
+- **Responsibilities**: Write tests from acceptance criteria (STEP 5a), verify Green (STEP 5c)
 - **Cannot**: Modify implementation code
 
 ### Evaluation AI
@@ -163,6 +173,120 @@ To prevent tunnel-vision bias, STEP 1 uses **information isolation** — not jus
 Merge all three analyses into a single implementation plan. Conflicts between phases must be explicitly resolved with rationale.
 
 **Do NOT give AI-A the issue content "for efficiency."** This destroys the core mechanism. See design rationale.
+
+---
+
+## STEP 3: Plan Evaluation
+
+**Evaluator**: Fresh-spawned Evaluation AI.
+
+**Input**: Implementation plan from STEP 2.
+
+**5 categories × 10 points**:
+
+| Category | Measures |
+|---|---|
+| Feasibility | Can this plan be implemented with the current structure? |
+| Dependencies | Are affected files and side effects identified? |
+| Scope | Appropriate — not too broad, not missing requirements? |
+| Consistency | Does this align with design-rationale.md principles? |
+| Test Plan | Are acceptance criteria testable? |
+
+**PASS**: avg >= 7.5, all >= 7 → STEP 4.
+**FAIL**: → STEP 2 (max 3x).
+
+---
+
+## STEP 4: Task Assignment
+
+The orchestrator creates a team and assigns tasks to teammates.
+
+```
+4-1. Spawn Test AI teammate
+     - SendMessage: acceptance criteria + verification design
+     - Instruction: "Write tests for these acceptance criteria. Do NOT implement."
+4-2. Spawn Developer AI teammate
+     - SendMessage: implementation plan + acceptance criteria
+     - Instruction: "Wait for Test AI to complete tests (STEP 5a). Then implement minimum code to pass."
+4-3. Both teammates receive: plan, acceptance criteria, affected files list
+```
+
+**[MUST]** Test AI starts first (STEP 5a). Developer AI waits until tests are written and Red-confirmed.
+
+---
+
+## STEP 5a-5d: Test-Driven Development Cycle
+
+### STEP 5a: Test Writing (Test AI)
+
+Test AI writes tests from acceptance criteria.
+
+```
+5a-1. Convert acceptance criteria → test scripts (tests/ directory)
+5a-2. Run tests → ALL must FAIL (Red confirmation)
+      - A test that passes means criteria already met or test is wrong
+5a-3. For untestable items → write manual verification checklist
+```
+
+### STEP 5b: Implementation (Developer AI)
+
+Developer AI writes minimum code to pass tests. This is the **only** step where implementation code is written.
+
+```
+5b-1. Read the tests from 5a
+5b-2. Write minimum code/content to pass tests
+      - [MUST] Do not implement behavior not covered by tests
+5b-3. Commit (feat/fix branch)
+```
+
+### STEP 5c: Green Verification
+
+```
+5c-1. Run all tests
+5c-2. Results:
+
+  All PASS → 5c-3
+
+  Some FAIL → Failure cause analysis:
+    ├─ Test issue → fix test → re-Red → STEP 5b re-entry
+    ├─ Implementation issue → fix implementation → STEP 5c retry
+    ├─ Both need fixes → fix test first → Red → fix impl → Green
+    └─ Deadlock (both claim "no problem") → fresh Evaluation AI arbitrates
+
+5c-3. Minimal implementation check:
+    Diff analysis: is there code NOT covered by any test?
+    ├─ All covered → PASS
+    ├─ Uncovered code exists → remove or add test
+    └─ Config/infra changes → exception allowed (document reason)
+```
+
+**Max round-trips**: STEP 5b↔5c max 3 cycles → human escalation.
+
+### STEP 5d: Refactor
+
+```
+5d-1. Code cleanup (no behavior change — tests must pass without modification)
+5d-2. Re-run all tests → Green maintained
+      - FAIL → refactor broke something → fix (max 2 attempts, then keep pre-refactor state)
+5d-3. Commit (refactor type)
+```
+
+### Pure Documentation Changes
+
+When the change is purely prose (no scripts, no templates with placeholders):
+- Skip TDD cycle (STEP 5a-5d) entirely
+- Proceed directly to STEP 6 evaluation
+- Document the skip reason: "Pure prose change — no testable behavior"
+
+### Regression Rules
+
+| Failure | Max Retries | Escalation |
+|---|---|---|
+| STEP 1.5 FAIL | 0 | Issue closed (by design) |
+| STEP 3 FAIL | 3 → STEP 2 | Human intervention |
+| STEP 5b↔5c cycle | 3 round-trips | Human intervention |
+| STEP 5d FAIL | 2 | Skip refactor, keep Green state |
+| STEP 6 FAIL | 3 → STEP 7 | Human intervention |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ Auto-Flow structures every code change through a defined lifecycle:
 STEP 0  Issue Analysis          — Understand the problem
 STEP 1  3-Phase Analysis        — Independent bias-free analysis
 STEP 2  Plan Synthesis          — Merge analyses into a plan
-STEP 3  Implementation          — Write the code
-STEP 4  Self-Review             — Developer reviews own work
-STEP 5  Testing                 — Independent test execution
+STEP 3  Plan Evaluation          — Scored plan assessment (gate)
+STEP 4  Task Assignment          — Delegate to Test AI and Developer AI
+STEP 5a Test Writing             — Tests from acceptance criteria (Red)
+STEP 5b Implementation           — Minimum code to pass tests
+STEP 5c Green Verification       — All tests pass + minimal check
+STEP 5d Refactor                 — Code cleanup, Green re-confirmation
 STEP 6  Evaluation              — Scored quality assessment (gate)
 STEP 7  Revision (if needed)    — Fix evaluation feedback
 STEP 8  PR & Review             — Submit for human review
@@ -26,8 +29,8 @@ STEP 9  Merge & Close           — Human approves and merges
 ### Key Features
 
 - **Multi-Agent Roles**: Orchestrator, Developer, Test, and Evaluation AIs with separated responsibilities
-- **3-Phase Independent Analysis**: Top-down, bottom-up, and lateral analysis to prevent tunnel-vision bias
-- **Evaluation Gate**: 10-point scoring system with defined PASS threshold (>= 7)
+- **3-Phase Independent Analysis**: Structure, Issue, and Cross-Verification analysis to prevent tunnel-vision bias
+- **Evaluation Gate**: 10-point scoring system with defined PASS threshold (>= 7.5)
 - **Hook Enforcement**: Shell hook validates Auto-Flow state before allowing commits/PRs
 - **Multi-Repo Support**: Orchestrator pattern for coordinating work across multiple repositories
 
@@ -125,7 +128,7 @@ At STEP 6, an independent Evaluation AI scores the work across 5 categories:
 | Security | 15% |
 | Performance | 15% |
 
-**Overall score >= 7** is required to proceed.
+**Overall score >= 7.5** is required to proceed, with no individual category below 7.
 
 ### 4. Hook Enforcement
 

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -108,7 +108,7 @@ The key principles:
 **Goal**: Merge the three analyses into a single, coherent implementation plan.
 
 ### Activities
-- Compare findings from Phase A, B, and C
+- Compare findings from Phase A, B, and Phase 3
 - Resolve conflicts with explicit rationale
 - Create a task breakdown with estimated scope
 - Identify risks and mitigation strategies
@@ -141,61 +141,110 @@ The key principles:
 
 ---
 
-## STEP 3: Implementation
+## STEP 3: Plan Evaluation
 
-**Goal**: Write the code according to the approved plan.
+**Goal**: An independent Evaluation AI scores the implementation plan before coding begins.
 
-### Activities
-- Follow the implementation plan from STEP 2
-- Write clean, production-quality code
-- Follow existing project conventions
-- Add inline comments only where logic is non-obvious
+> **The Evaluation AI is spawned fresh** for this step — it carries no prior conversation history.
 
-### Rules
-- Stay within your assigned repository
-- Do not modify code outside the plan scope
-- If the plan needs adjustment, raise a Discussion before proceeding
+### Process
+1. A freshly spawned Evaluation AI receives the implementation plan from STEP 2
+2. Scores across 5 categories (Feasibility, Dependencies, Scope, Consistency, Test Plan)
+3. Produces a scored evaluation
+
+### PASS / FAIL
+- **PASS** (score >= 7.5, all categories >= 7): Proceed to STEP 4
+- **FAIL**: Return to STEP 2 (max 3 revision cycles)
 
 ### Exit Criteria
-- Code compiles/builds successfully
-- Basic functionality works as intended
-- No linting errors
+- Evaluation report saved
+- PASS → proceed to STEP 4
+- FAIL → return to STEP 2 for plan revision
 
 ---
 
-## STEP 4: Self-Review
+## STEP 4: Task Assignment
 
-**Goal**: The Developer AI reviews its own work before handing off to testing.
+**Goal**: The orchestrator delegates implementation work to Test AI and Developer AI teammates.
 
-### Checklist
-- [ ] Code matches the implementation plan
-- [ ] No debug/temporary code left in
-- [ ] No hardcoded secrets or credentials
-- [ ] Error handling is appropriate (not excessive)
-- [ ] Code follows existing project patterns
-- [ ] No unnecessary changes outside scope
+### Activities
+- Spawn Test AI teammate with acceptance criteria
+- Spawn Developer AI teammate with implementation plan
+- Test AI starts first (STEP 5a) — Developer AI waits
 
 ### Exit Criteria
-- Self-review checklist completed
-- Any issues found are fixed
-- Code is ready for testing
+- Tasks assigned to teammates
+- Test AI and Developer AI have received their instructions
 
 ---
 
-## STEP 5: Testing
+## STEP 5a: Test Writing (Test AI)
 
-**Goal**: Test AI writes and runs tests to verify the implementation.
+**Goal**: Test AI writes tests from acceptance criteria. Tests must all FAIL (Red confirmation).
 
 ### Activities
-- Write unit tests for new/changed functions
-- Write integration tests if cross-component changes exist
-- Run the full test suite
-- Verify no existing tests are broken
+- Convert acceptance criteria into test scripts
+- Run tests — ALL must FAIL (Red confirmation)
+- A test that passes means criteria already met or test is wrong
+- For untestable items, write manual verification checklist
 
 ### Exit Criteria
-- All new tests pass
-- All existing tests pass
-- Test coverage for critical paths is adequate
+- All tests written
+- All tests FAIL (Red confirmed)
+- Ready for Developer AI implementation
+
+---
+
+## STEP 5b: Implementation (Developer AI)
+
+**Goal**: Developer AI writes minimum code to pass tests.
+
+### Activities
+- Read the tests from STEP 5a
+- Write minimum code/content to pass tests
+- Do not implement behavior not covered by tests
+- Commit changes
+
+### Exit Criteria
+- Minimum implementation complete
+- Ready for Green verification
+
+---
+
+## STEP 5c: Green Verification
+
+**Goal**: All tests pass and implementation is minimal.
+
+### Activities
+- Run all tests
+- If some fail, analyze failure cause:
+  - **Test issue**: Fix test → re-Red → STEP 5b re-entry
+  - **Implementation issue**: Fix implementation → STEP 5c retry
+  - **Both need fixes**: Fix test first → Red → fix impl → Green
+  - **Deadlock** (both claim "no problem"): Fresh Evaluation AI arbitrates
+- Minimal implementation check: verify no code exists that isn't covered by tests
+
+### Exit Criteria
+- All tests pass (Green)
+- No uncovered implementation code
+- Max round-trips: STEP 5b↔5c max 3 cycles → human escalation
+
+---
+
+## STEP 5d: Refactor
+
+**Goal**: Code cleanup without changing behavior. Tests must pass without modification.
+
+### Activities
+- Clean up code (no behavior change)
+- Re-run all tests → Green maintained
+- If refactor breaks tests → fix (max 2 attempts, then keep pre-refactor state)
+- Commit (refactor type)
+
+### Exit Criteria
+- Code cleaned up
+- All tests still pass (Green maintained)
+- Ready for evaluation
 
 ---
 
@@ -295,10 +344,12 @@ When a STEP fails, the flow regresses — or terminates:
 | Failure Point | Action | Reason |
 |--------------|--------|--------|
 | STEP 1.5 (structure eval FAIL) | **Close issue** | Existing structure already handles it |
-| STEP 5 (tests fail) | → STEP 3 | Fix implementation |
+| STEP 3 (plan eval FAIL) | → STEP 2 (max 3x) | Plan revision needed |
+| STEP 5b↔5c cycle (tests fail) | → STEP 5b (max 3 round-trips) | Fix implementation or tests |
+| STEP 5d (refactor breaks tests) | Fix (max 2 attempts) | Keep pre-refactor state |
 | STEP 6 (score < 7.5) | → STEP 7 | Revision needed |
 | STEP 6 (security <= 3) | → STEP 3 | Mandatory major rework |
-| STEP 8 (CI fails) | → STEP 5 | Re-test |
+| STEP 8 (CI fails) | → STEP 5a | Re-test |
 | STEP 9 (human rejects) | → STEP 7 | Address human feedback |
 
 ---
@@ -312,9 +363,9 @@ When a STEP fails, the flow regresses — or terminates:
     ├── step               # Contains: current step number
     ├── requirements.md    # STEP 0 output
     ├── analysis/
-    │   ├── phase-a.md     # Top-down analysis
-    │   ├── phase-b.md     # Bottom-up analysis
-    │   └── phase-c.md     # Lateral analysis
+    │   ├── phase-a.md     # Structure analysis
+    │   ├── phase-b.md     # Issue analysis
+    │   └── phase-3.md     # Cross-verification
     ├── plan.md            # STEP 2 output
     ├── evaluation.json    # STEP 6 output
     └── history.log        # Step transition log

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -10,7 +10,7 @@ The Evaluation AI is an **independent agent** that scores completed work before 
 
 ### Critical Rule: Fresh Spawn Every Time
 
-**The Evaluation AI must be spawned fresh for every evaluation** — at STEPs 1.5, 3, 5.7, and 6. It carries no prior conversation history. This is mandatory, not optional.
+**The Evaluation AI must be spawned fresh for every evaluation** — at STEPs 1.5, 3, and 6. It carries no prior conversation history. This is mandatory, not optional.
 
 **Why**: When the same agent creates a plan and evaluates it, it struggles to reject its own work. A freshly spawned agent sees only the deliverable — it has no investment in the process. Bias elimination takes priority over token cost savings. See [docs/design-rationale.md](design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
 
@@ -157,7 +157,7 @@ The Evaluation AI receives:
 1. **Issue requirements** (`.autoflow-state/<issue>/requirements.md`)
 2. **Implementation plan** (`.autoflow-state/<issue>/plan.md`)
 3. **Code diff** (`git diff` of the changes)
-4. **Test results** (test output from STEP 5)
+4. **Test results** (test output from STEP 5c)
 5. **Security checklist** (from `docs/security-checklist.md`)
 
 ### Evaluation Steps

--- a/tests/test-tdd-cycle-restoration.sh
+++ b/tests/test-tdd-cycle-restoration.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Test: TDD Cycle Restoration (Issue #4)
+# Verifies STEP 5a/5b/5c/5d sub-steps are present in template files.
+# All tests should FAIL (Red) before implementation.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+TEMPLATE="$REPO_ROOT/CLAUDE.md.template"
+GUIDE="$REPO_ROOT/docs/autoflow-guide.md"
+EVAL_SYSTEM="$REPO_ROOT/docs/evaluation-system.md"
+README="$REPO_ROOT/README.md"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+  echo "  PASS: $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "  FAIL: $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ---------- AC 1: Lifecycle table STEP 3 = "Plan Evaluation" ----------
+test_ac1_step3_plan_evaluation() {
+  echo "AC1: CLAUDE.md.template lifecycle table shows STEP 3 as Plan Evaluation"
+  # Look for a table row with STEP 3 and "Plan Evaluation" (not "Implementation")
+  if grep -E '^\| *3 .*Plan Evaluation' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "STEP 3 is Plan Evaluation"
+  else
+    fail "STEP 3 is not Plan Evaluation in lifecycle table"
+  fi
+}
+
+# ---------- AC 2: Lifecycle table STEP 4 = "Task Assignment" ----------
+test_ac2_step4_task_assignment() {
+  echo "AC2: CLAUDE.md.template lifecycle table shows STEP 4 as Task Assignment"
+  if grep -E '^\| *4 .*Task Assignment' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "STEP 4 is Task Assignment"
+  else
+    fail "STEP 4 is not Task Assignment in lifecycle table"
+  fi
+}
+
+# ---------- AC 3: Template contains STEP 5a, 5b, 5c, 5d references ----------
+test_ac3_step5_substeps() {
+  echo "AC3: CLAUDE.md.template contains STEP 5a, 5b, 5c, 5d references"
+  local all_found=true
+  for sub in 5a 5b 5c 5d; do
+    if ! grep -q "STEP $sub" "$TEMPLATE" 2>/dev/null; then
+      all_found=false
+      break
+    fi
+  done
+  if $all_found; then
+    pass "All STEP 5a/5b/5c/5d references found"
+  else
+    fail "Missing one or more STEP 5a/5b/5c/5d references"
+  fi
+}
+
+# ---------- AC 4: Flow Control Table includes 5a->5b->5c->5d transitions ----------
+test_ac4_flow_control_transitions() {
+  echo "AC4: Flow Control Table in CLAUDE.md.template includes 5a->5b->5c->5d transitions"
+  # Check for flow control rows mentioning 5a, 5b, 5c, 5d
+  local count
+  count=$(grep -cE '^\|.*STEP 5[abcd]' "$TEMPLATE" 2>/dev/null || true)
+  count=${count:-0}
+  # Ensure count is a single number
+  count=$(echo "$count" | tail -1)
+  if [ "$count" -ge 4 ]; then
+    pass "Flow control table has 5a/5b/5c/5d transitions"
+  else
+    fail "Flow control table missing 5a/5b/5c/5d transitions (found $count rows)"
+  fi
+}
+
+# ---------- AC 5: STEP 5a requires Red confirmation ----------
+test_ac5_red_confirmation() {
+  echo "AC5: STEP 5a section requires Red confirmation (tests must FAIL)"
+  if grep -qi 'red.*confirm\|must.*fail\|all.*fail' "$TEMPLATE" 2>/dev/null &&
+     grep -q '5a' "$TEMPLATE" 2>/dev/null; then
+    # More specific: check that Red confirmation appears in context of 5a
+    # Extract section around 5a and check for Red/FAIL
+    if sed -n '/STEP 5a/,/STEP 5[bcd]/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'red|must.*fail|all.*fail'; then
+      pass "STEP 5a requires Red confirmation"
+    else
+      fail "STEP 5a does not mention Red confirmation"
+    fi
+  else
+    fail "STEP 5a section with Red confirmation not found"
+  fi
+}
+
+# ---------- AC 6: STEP 5b states minimum implementation principle ----------
+test_ac6_minimum_implementation() {
+  echo "AC6: STEP 5b states minimum implementation principle"
+  if sed -n '/STEP 5b/,/STEP 5[cd]/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'minimum.*code|minimum.*implementation|not.*implement.*beyond.*test|do not implement.*not covered'; then
+    pass "STEP 5b states minimum implementation principle"
+  else
+    fail "STEP 5b minimum implementation principle not found"
+  fi
+}
+
+# ---------- AC 7: STEP 5c includes 4 failure paths ----------
+test_ac7_four_failure_paths() {
+  echo "AC7: STEP 5c includes 4 failure paths (test issue, impl issue, both, deadlock)"
+  local section
+  section=$(sed -n '/STEP 5c/,/STEP 5d/p' "$TEMPLATE" 2>/dev/null)
+  if [ -z "$section" ]; then
+    fail "STEP 5c section not found"
+    return
+  fi
+  local paths_found=0
+  echo "$section" | grep -qiE 'test issue|test incorrect' && paths_found=$((paths_found + 1))
+  echo "$section" | grep -qiE 'impl.* issue|implementation.* issue|implementation incorrect' && paths_found=$((paths_found + 1))
+  echo "$section" | grep -qiE 'both' && paths_found=$((paths_found + 1))
+  echo "$section" | grep -qiE 'deadlock' && paths_found=$((paths_found + 1))
+  if [ "$paths_found" -ge 4 ]; then
+    pass "All 4 failure paths found in STEP 5c"
+  else
+    fail "Only $paths_found of 4 failure paths found in STEP 5c"
+  fi
+}
+
+# ---------- AC 8: Deadlock path mentions fresh Evaluation AI ----------
+test_ac8_deadlock_fresh_eval() {
+  echo "AC8: Deadlock path mentions fresh Evaluation AI"
+  local section
+  section=$(sed -n '/STEP 5c/,/STEP 5d/p' "$TEMPLATE" 2>/dev/null)
+  if [ -z "$section" ]; then
+    fail "STEP 5c section not found for deadlock check"
+    return
+  fi
+  if echo "$section" | grep -qiE 'deadlock.*evaluation.*ai|evaluation.*ai.*arbitrat'; then
+    pass "Deadlock path mentions fresh Evaluation AI"
+  else
+    fail "Deadlock path does not mention fresh Evaluation AI"
+  fi
+}
+
+# ---------- AC 9: 5b<->5c round-trip limit: max 3 cycles ----------
+test_ac9_roundtrip_limit() {
+  echo "AC9: 5b<->5c round-trip limit: max 3 cycles documented"
+  if grep -qE '5b.*5c.*3|max.*3.*cycle|3.*round.?trip' "$TEMPLATE" 2>/dev/null; then
+    pass "5b<->5c max 3 cycle limit documented"
+  else
+    fail "5b<->5c max 3 cycle limit not found"
+  fi
+}
+
+# ---------- AC 10: STEP 5d includes refactor + Green re-confirmation + max 2 ----------
+test_ac10_refactor_green() {
+  echo "AC10: STEP 5d includes refactor with Green re-confirmation, max 2 attempts"
+  local section
+  section=$(sed -n '/STEP 5d/,/STEP [67]/p' "$TEMPLATE" 2>/dev/null)
+  if [ -z "$section" ]; then
+    fail "STEP 5d section not found"
+    return
+  fi
+  local checks=0
+  echo "$section" | grep -qiE 'refactor' && checks=$((checks + 1))
+  echo "$section" | grep -qiE 'green|tests.*pass|re-run.*test' && checks=$((checks + 1))
+  echo "$section" | grep -qiE 'max.*2|2.*attempt' && checks=$((checks + 1))
+  if [ "$checks" -ge 3 ]; then
+    pass "STEP 5d has refactor, Green re-confirmation, max 2 attempts"
+  else
+    fail "STEP 5d missing elements ($checks of 3 found)"
+  fi
+}
+
+# ---------- AC 11: autoflow-guide.md contains STEP 5a/5b/5c/5d subsections ----------
+test_ac11_guide_substeps() {
+  echo "AC11: autoflow-guide.md contains STEP 5a/5b/5c/5d subsections"
+  local all_found=true
+  for sub in 5a 5b 5c 5d; do
+    if ! grep -qE '#+.*STEP '$sub'|#+.*5'${sub: -1} "$GUIDE" 2>/dev/null; then
+      all_found=false
+      break
+    fi
+  done
+  if $all_found; then
+    pass "autoflow-guide.md has STEP 5a/5b/5c/5d subsections"
+  else
+    fail "autoflow-guide.md missing STEP 5a/5b/5c/5d subsections"
+  fi
+}
+
+# ---------- AC 12: autoflow-guide.md regression rules include 5b<->5c cycle limits ----------
+test_ac12_guide_regression() {
+  echo "AC12: autoflow-guide.md regression rules include 5b<->5c cycle limits"
+  if grep -qE '5b.*5c|5c.*5b' "$GUIDE" 2>/dev/null; then
+    pass "autoflow-guide.md regression rules include 5b<->5c cycle limits"
+  else
+    fail "autoflow-guide.md missing 5b<->5c cycle limits in regression rules"
+  fi
+}
+
+# ---------- AC 13: autoflow-guide.md uses "phase-3.md" (not "phase-c.md") ----------
+test_ac13_phase3_filename() {
+  echo "AC13: autoflow-guide.md uses phase-3.md (not phase-c.md) in state file structure"
+  if grep -q 'phase-3\.md' "$GUIDE" 2>/dev/null; then
+    pass "autoflow-guide.md uses phase-3.md"
+  else
+    fail "autoflow-guide.md does not use phase-3.md (may use phase-c.md instead)"
+  fi
+}
+
+# ---------- AC 14: evaluation-system.md does NOT contain "5.7" reference ----------
+test_ac14_no_5_7() {
+  echo "AC14: evaluation-system.md does NOT contain 5.7 reference"
+  if grep -q '5\.7' "$EVAL_SYSTEM" 2>/dev/null; then
+    fail "evaluation-system.md still contains 5.7 reference"
+  else
+    pass "evaluation-system.md does not contain 5.7 reference"
+  fi
+}
+
+# ---------- AC 15: evaluation-system.md references "STEP 5c" ----------
+test_ac15_eval_step5c() {
+  echo "AC15: evaluation-system.md references STEP 5c (not flat STEP 5)"
+  if grep -q 'STEP 5c' "$EVAL_SYSTEM" 2>/dev/null; then
+    pass "evaluation-system.md references STEP 5c"
+  else
+    fail "evaluation-system.md does not reference STEP 5c"
+  fi
+}
+
+# ---------- AC 16: README.md lifecycle table shows updated STEP 3/4/5 names ----------
+test_ac16_readme_lifecycle() {
+  echo "AC16: README.md lifecycle table shows updated STEP 3/4/5 names"
+  local checks=0
+  grep -qE 'STEP 3.*Plan Evaluation' "$README" 2>/dev/null && checks=$((checks + 1))
+  grep -qE 'STEP 4.*Task Assignment' "$README" 2>/dev/null && checks=$((checks + 1))
+  grep -qE 'STEP 5a' "$README" 2>/dev/null && checks=$((checks + 1))
+  if [ "$checks" -ge 3 ]; then
+    pass "README.md lifecycle table updated for STEP 3/4/5"
+  else
+    fail "README.md lifecycle table not updated ($checks of 3 checks passed)"
+  fi
+}
+
+# ---------- AC 17: Pure documentation changes bypass guidance ----------
+test_ac17_pure_docs_bypass() {
+  echo "AC17: Pure documentation changes bypass guidance exists in CLAUDE.md.template"
+  if grep -qiE 'pure.*doc.*change|pure.*prose.*change|skip.*tdd|skip.*step.*5|bypass.*test' "$TEMPLATE" 2>/dev/null; then
+    pass "Pure documentation changes bypass guidance found"
+  else
+    fail "Pure documentation changes bypass guidance not found"
+  fi
+}
+
+# ========== Run all tests ==========
+echo "============================================"
+echo "Test Suite: TDD Cycle Restoration (Issue #4)"
+echo "============================================"
+echo ""
+
+test_ac1_step3_plan_evaluation
+test_ac2_step4_task_assignment
+test_ac3_step5_substeps
+test_ac4_flow_control_transitions
+test_ac5_red_confirmation
+test_ac6_minimum_implementation
+test_ac7_four_failure_paths
+test_ac8_deadlock_fresh_eval
+test_ac9_roundtrip_limit
+test_ac10_refactor_green
+test_ac11_guide_substeps
+test_ac12_guide_regression
+test_ac13_phase3_filename
+test_ac14_no_5_7
+test_ac15_eval_step5c
+test_ac16_readme_lifecycle
+test_ac17_pure_docs_bypass
+
+echo ""
+echo "============================================"
+echo "Results: $PASS_COUNT PASS / $FAIL_COUNT FAIL (total $((PASS_COUNT + FAIL_COUNT)))"
+echo "============================================"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Replace simplified waterfall (Implementation → Self-Review → Test) with proven TDD cycle from ontology-platform
- STEP 3 → Plan Evaluation gate, STEP 4 → Task Assignment, STEP 5 → 5a/5b/5c/5d (Red/Green/Refactor)
- Fix ancillary issues: STEP 5.7 stale reference, phase-c→phase-3 naming, README PASS threshold

## Changed Files

| File | Change |
|------|--------|
| `CLAUDE.md.template` | Restructured STEPs 3-5, added TDD cycle sections, updated flow control/agent roles/regression rules |
| `docs/autoflow-guide.md` | Replaced STEP 3/4/5 with Plan Eval/Task Assignment/TDD cycle, fixed phase naming |
| `docs/evaluation-system.md` | Fixed STEP 5.7 reference, updated STEP 5 → STEP 5c |
| `README.md` | Updated lifecycle table and PASS threshold |
| `tests/test-tdd-cycle-restoration.sh` | 17 acceptance criteria tests (all pass) |

## Evaluation

STEP 6 PASS — weighted score 8.45/10 (Correctness 9, Quality 8, Test Coverage 8, Security 9, Performance 8)

## Test plan

- [x] 17/17 acceptance criteria tests pass (`bash tests/test-tdd-cycle-restoration.sh`)
- [ ] Manual review: TDD cycle sections are clear and actionable for template users
- [ ] Manual review: cross-file consistency (template ↔ guide ↔ eval doc)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)