### PR TITLE
feat(#5): restore STEP 0 as Pre-Work (Git Clean Check)

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -52,8 +52,8 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 
 | STEP | Name | Description | Exit Criteria |
 |------|------|-------------|---------------|
-| 0 | **Issue Analysis** | Understand the issue/request thoroughly | Issue requirements documented |
-| 1 | **3-Phase Analysis** | Information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
+| 0 | **Pre-Work** | Git clean check, upstream sync, branch creation | Git clean, branch created |
+| 1 | **3-Phase Analysis** | Understand the issue + information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
 | 1.5 | **Issue Analysis Eval** | Gate: is the analysis sufficient? | Score >= 7.5 or issue closed |
 | 2 | **Plan Synthesis** | Merge analyses into implementation plan | Plan approved |
 | 3 | **Plan Evaluation** | Fresh Evaluation AI scores the plan | Score >= 7.5, all >= 7 |
@@ -70,11 +70,25 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 ### Execution Principles
 
 1. **Never skip steps.** Each STEP builds on the previous one — regardless of change size. "This one is simple" is itself a biased judgment.
-2. **Regression is allowed.** If STEP 6 fails, return to STEP 7 (or STEP 3 for major issues).
-3. **STEP 1.5 FAIL = issue close.** If existing structure handles the concern, no code change is needed.
-4. **Human gates exist.** STEP 8→9 always requires human approval.
-5. **State is tracked.** Use `.autoflow-state/` files to persist STEP status.
-6. **Pipeline is stateless.** Past issue evaluations do not influence current analysis. Improvement happens outside the pipeline, through human-driven CLAUDE.md updates.
+2. **STEP 0 is mandatory.** If Git state is not clean, STEP 1 does not begin.
+3. **Regression is allowed.** If STEP 6 fails, return to STEP 7 (or STEP 3 for major issues).
+4. **STEP 1.5 FAIL = issue close.** If existing structure handles the concern, no code change is needed.
+5. **Human gates exist.** STEP 8→9 always requires human approval.
+6. **State is tracked.** Use `.autoflow-state/` files to persist STEP status.
+7. **Pipeline is stateless.** Past issue evaluations do not influence current analysis. Improvement happens outside the pipeline, through human-driven CLAUDE.md updates.
+
+### STEP 0: Pre-Work
+
+**[MUST]** Git Clean Check before any work begins.
+
+```
+0-1. git status — no uncommitted changes, no untracked files in working area
+0-2. git fetch origin — sync with remote
+0-3. Resolve any dirty state (stash, commit, or discard with user approval)
+0-4. git checkout -b <branch-type>/<issue>-<desc> main
+```
+
+If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to STEP 1.
 
 ---
 
@@ -82,7 +96,7 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 
 | Current State | Condition | Next State |
 |--------------|-----------|------------|
-| STEP 0 | Issue analyzed | → STEP 1 |
+| STEP 0 | Git clean, branch created | → STEP 1 |
 | STEP 1 | 3 isolated analyses done | → STEP 1.5 |
 | STEP 1.5 (score >= 7.5) | PASS | → STEP 2 |
 | STEP 1.5 (FAIL) | Existing structure sufficient | → **Issue closed** |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Auto-Flow is a **10-step development lifecycle** that ensures quality through mu
 Auto-Flow structures every code change through a defined lifecycle:
 
 ```
-STEP 0  Issue Analysis          — Understand the problem
+STEP 0  Pre-Work                — Git clean check, branch creation
 STEP 1  3-Phase Analysis        — Independent bias-free analysis
 STEP 2  Plan Synthesis          — Merge analyses into a plan
 STEP 3  Plan Evaluation          — Scored plan assessment (gate)

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -16,23 +16,23 @@ The key principles:
 
 ---
 
-## STEP 0: Issue Analysis
+## STEP 0: Pre-Work
 
-**Goal**: Fully understand what needs to be done before any planning or coding.
+**Goal**: Ensure a clean Git state before any analysis or coding begins.
 
 ### Activities
-- Read the issue/request carefully
-- Identify acceptance criteria
-- Clarify ambiguities (use Discussion Protocol if needed)
-- Document requirements summary
+- `git status` — verify no uncommitted changes or untracked files in working area
+- `git fetch origin` — sync with remote
+- Resolve any dirty state (stash, commit, or discard with user approval)
+- `git checkout -b <branch-type>/<issue>-<desc> main` — create feature branch from latest main
 
 ### Exit Criteria
-- Requirements are documented in `.autoflow-state/<issue>/requirements.md`
-- All ambiguities resolved or explicitly noted as assumptions
+- Git working tree is clean
+- Branch created from latest main
+- Ready for STEP 1 analysis
 
-### Common Mistakes
-- Starting to code before fully understanding the issue
-- Assuming requirements that aren't stated
+### Hard Stop Rule
+If Git state is not clean after resolution attempts, **stop and report to user**. Do NOT proceed to STEP 1. Starting work on a dirty Git state causes merge conflicts, lost changes, and broken state downstream.
 
 ---
 
@@ -361,7 +361,7 @@ When a STEP fails, the flow regresses — or terminates:
 ├── current-issue          # Contains: issue number
 └── <issue-number>/
     ├── step               # Contains: current step number
-    ├── requirements.md    # STEP 0 output
+    ├── requirements.md    # STEP 1 output (issue requirements)
     ├── analysis/
     │   ├── phase-a.md     # Structure analysis
     │   ├── phase-b.md     # Issue analysis

--- a/tests/test-step0-restoration.sh
+++ b/tests/test-step0-restoration.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Test Suite: STEP 0 Pre-Work Restoration (Issue #5)
+# Validates that STEP 0 is "Pre-Work" (Git Clean Check) across all docs
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+assert_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -q "$pattern" "$file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' not found in $file)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -q "$pattern" "$file" 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' found in $file)")
+    echo "  FAIL: $desc"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
+TEMPLATE="CLAUDE.md.template"
+GUIDE="docs/autoflow-guide.md"
+README="README.md"
+EVAL_SYSTEM="docs/evaluation-system.md"
+
+echo "=== Test Suite: STEP 0 Pre-Work Restoration ==="
+echo ""
+
+# --- CLAUDE.md.template tests ---
+echo "--- CLAUDE.md.template ---"
+
+assert_contains "$TEMPLATE" "Pre-Work" \
+  "T1: CLAUDE.md.template STEP 0 contains 'Pre-Work'"
+
+assert_contains "$TEMPLATE" "git status" \
+  "T2: CLAUDE.md.template STEP 0 includes git status check"
+
+assert_contains "$TEMPLATE" "git fetch" \
+  "T3: CLAUDE.md.template STEP 0 includes git fetch"
+
+assert_not_contains "$TEMPLATE" "| 0 | \*\*Issue Analysis\*\*" \
+  "T4: CLAUDE.md.template STEP 0 is NOT 'Issue Analysis'"
+
+assert_contains "$TEMPLATE" "Git clean.*branch created\|branch created.*Git clean" \
+  "T5: CLAUDE.md.template Flow Control shows STEP 0 exit as git clean + branch"
+
+# --- docs/autoflow-guide.md tests ---
+echo ""
+echo "--- docs/autoflow-guide.md ---"
+
+assert_contains "$GUIDE" "Pre-Work" \
+  "T6: autoflow-guide.md STEP 0 contains 'Pre-Work'"
+
+assert_contains "$GUIDE" "git status" \
+  "T7: autoflow-guide.md STEP 0 includes git status check"
+
+assert_contains "$GUIDE" "git fetch" \
+  "T8: autoflow-guide.md STEP 0 includes git fetch"
+
+assert_not_contains "$GUIDE" "## STEP 0: Issue Analysis" \
+  "T9: autoflow-guide.md STEP 0 is NOT titled 'Issue Analysis'"
+
+# --- README.md tests ---
+echo ""
+echo "--- README.md ---"
+
+assert_contains "$README" "STEP 0.*Pre-Work\|STEP 0.*Git Clean" \
+  "T10: README.md STEP 0 shows Pre-Work or Git Clean Check"
+
+assert_not_contains "$README" "STEP 0.*Issue Analysis" \
+  "T11: README.md STEP 0 is NOT 'Issue Analysis'"
+
+# --- Cross-file consistency ---
+echo ""
+echo "--- Cross-file consistency ---"
+
+assert_not_contains "$TEMPLATE" "| STEP 0 | Issue analyzed" \
+  "T12: Flow Control table does not reference 'Issue analyzed' for STEP 0"
+
+# --- Evaluation system unchanged ---
+echo ""
+echo "--- Evaluation system ---"
+
+# evaluation-system.md should not define STEP 0 content at all
+assert_not_contains "$EVAL_SYSTEM" "STEP 0" \
+  "T13: evaluation-system.md does not reference STEP 0"
+
+# --- STEP 1 absorbs issue understanding ---
+echo ""
+echo "--- STEP 1 absorption ---"
+
+assert_contains "$GUIDE" "## STEP 1" \
+  "T14: autoflow-guide.md has STEP 1 section"
+
+# State file structure: requirements.md annotation should reference Pre-Work or STEP 0-1
+assert_not_contains "$GUIDE" "requirements.md.*# STEP 0 output" \
+  "T15: State file annotation does not label requirements.md as 'STEP 0 output' specifically"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [ $FAIL -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  $err"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

- STEP 0을 "Issue Analysis"에서 "Pre-Work" (Git Clean Check)로 복원
- `CLAUDE.md.template`, `docs/autoflow-guide.md`, `README.md` 3개 파일 일관 업데이트
- 15개 테스트 케이스로 변경사항 검증 완료 (STEP 6 평가 8.45/10 PASS)

## Changes

| File | Change |
|------|--------|
| `CLAUDE.md.template` | STEP 0 → Pre-Work, Execution Principles에 "STEP 0 is mandatory" 추가, Flow Control 업데이트 |
| `docs/autoflow-guide.md` | STEP 0 → Pre-Work with git operations, Hard Stop Rule 추가 |
| `README.md` | STEP summary 업데이트 |
| `tests/test-step0-restoration.sh` | 15개 테스트 (Pre-Work 존재, Issue Analysis 부재, 일관성 검증) |

## Test plan

- [x] 15/15 tests pass (`bash tests/test-step0-restoration.sh`)
- [x] STEP 6 evaluation PASS (weighted avg 8.45/10)
- [ ] Manual review: verify STEP 0 Pre-Work content matches CLAUDE.md

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)