### PR TITLE
feat(#7): strengthen Discussion Protocol with bias-prevention mechanisms

### DIFF
--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -357,30 +357,26 @@ When the change is purely prose (no scripts, no templates with placeholders):
 
 ## Discussion Protocol
 
-When ambiguity or disagreement arises during any STEP, follow this protocol:
+When ambiguity or disagreement arises:
 
-1. **Raise**: The agent encountering the issue documents it clearly
-2. **Context**: Include what was attempted, what failed, and why it matters
-3. **Options**: Present at least 2 viable options with trade-offs
-4. **Recommend**: State a recommendation with rationale
-5. **Escalate**: If agents disagree, escalate to the Orchestrator. If the Orchestrator cannot resolve, escalate to a human.
-
-### Format
+### Process
 
 ```
-## Discussion: [Brief Title]
-
-**Raised by**: [Agent Role]
-**STEP**: [Current STEP number]
-**Context**: [What happened]
-
-### Options
-1. **Option A**: [Description] — Trade-off: [...]
-2. **Option B**: [Description] — Trade-off: [...]
-
-### Recommendation
-[Which option and why]
+1. UNDERSTAND — Read and comprehend the claim
+2. VERIFY    — Check against actual files/data (mandatory — cannot evaluate without reading)
+3. EVALUATE  — Form judgment with evidence
+4. RESPOND   — One of:
+   - ACCEPT: with specific evidence (no groundless agreement)
+   - COUNTER: with alternative + evidence
+   - PARTIAL: accept parts, counter others
+   - ESCALATE: to human with context
 ```
+
+### Rules
+
+- **No agreement without evidence.** "That sounds right" is not ACCEPT. Cite specific files or data.
+- **First exchange devil's advocate.** On the first interaction about a proposal, include at least one counter-argument. This prevents premature consensus.
+- **Cannot evaluate without reading.** Opinions about code/templates require having read the relevant files.
 
 ---
 

--- a/tests/test-discussion-protocol.sh
+++ b/tests/test-discussion-protocol.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Test Suite: Discussion Protocol Update (Issue #7)
+# Validates that CLAUDE.md.template Discussion Protocol matches CLAUDE.md's
+# evidence-oriented version with UNDERSTAND/VERIFY/EVALUATE/RESPOND cycle.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+assert_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -q "$pattern" "$file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' not found in $file)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_not_contains() {
+  local file="$1" pattern="$2" desc="$3"
+  if grep -q "$pattern" "$file" 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' found in $file)")
+    echo "  FAIL: $desc"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
+TEMPLATE="CLAUDE.md.template"
+CLAUDE_MD="CLAUDE.md"
+
+echo "=== Test Suite: Discussion Protocol Update (Issue #7) ==="
+echo ""
+
+# --- AC1: 4-step UNDERSTAND/VERIFY/EVALUATE/RESPOND cycle ---
+echo "--- AC1: 4-step cycle in CLAUDE.md.template ---"
+
+assert_contains "$TEMPLATE" "UNDERSTAND" \
+  "T1: Template contains UNDERSTAND step"
+
+assert_contains "$TEMPLATE" "VERIFY" \
+  "T2: Template contains VERIFY step"
+
+assert_contains "$TEMPLATE" "EVALUATE" \
+  "T3: Template contains EVALUATE step"
+
+assert_contains "$TEMPLATE" "RESPOND" \
+  "T4: Template contains RESPOND step"
+
+assert_contains "$TEMPLATE" "UNDERSTAND.*VERIFY\|1\..*UNDERSTAND" \
+  "T5: Template has numbered UNDERSTAND/VERIFY/EVALUATE/RESPOND process"
+
+echo ""
+
+# --- AC2: Three enforcement rules ---
+echo "--- AC2: Three enforcement rules ---"
+
+assert_contains "$TEMPLATE" "No agreement without evidence" \
+  "T6: Template contains 'No agreement without evidence' rule"
+
+assert_contains "$TEMPLATE" "First exchange devil's advocate\|first exchange devil" \
+  "T7: Template contains 'First exchange devil's advocate' rule"
+
+assert_contains "$TEMPLATE" "Cannot evaluate without reading\|cannot evaluate without reading" \
+  "T8: Template contains 'Cannot evaluate without reading' rule"
+
+echo ""
+
+# --- AC3: Structured response types ---
+echo "--- AC3: Structured response types (ACCEPT/COUNTER/PARTIAL/ESCALATE) ---"
+
+assert_contains "$TEMPLATE" "ACCEPT" \
+  "T9: Template contains ACCEPT response type"
+
+assert_contains "$TEMPLATE" "COUNTER" \
+  "T10: Template contains COUNTER response type"
+
+assert_contains "$TEMPLATE" "PARTIAL" \
+  "T11: Template contains PARTIAL response type"
+
+assert_contains "$TEMPLATE" "ESCALATE" \
+  "T12: Template contains ESCALATE response type"
+
+assert_contains "$TEMPLATE" "with specific evidence\|no groundless agreement" \
+  "T13: ACCEPT response includes evidence requirement"
+
+echo ""
+
+# --- AC4: Old protocol fully removed ---
+echo "--- AC4: Old 5-step protocol removed ---"
+
+assert_not_contains "$TEMPLATE" "1\. \*\*Raise\*\*" \
+  "T14: Old 'Raise' step removed"
+
+assert_not_contains "$TEMPLATE" "2\. \*\*Context\*\*: Include what was attempted" \
+  "T15: Old 'Context' step removed"
+
+assert_not_contains "$TEMPLATE" "3\. \*\*Options\*\*: Present at least 2" \
+  "T16: Old 'Options' step removed"
+
+assert_not_contains "$TEMPLATE" "4\. \*\*Recommend\*\*: State a recommendation" \
+  "T17: Old 'Recommend' step removed"
+
+assert_not_contains "$TEMPLATE" "5\. \*\*Escalate\*\*: If agents disagree" \
+  "T18: Old 'Escalate' step removed"
+
+assert_not_contains "$TEMPLATE" "Raised by.*Agent Role" \
+  "T19: Old discussion format template removed"
+
+assert_not_contains "$TEMPLATE" "Option A.*Description.*Trade-off" \
+  "T20: Old options format removed"
+
+echo ""
+
+# --- AC5: Structure matches CLAUDE.md ---
+echo "--- AC5: Structure matches CLAUDE.md Discussion Protocol ---"
+
+assert_contains "$TEMPLATE" "### Process" \
+  "T21: Template has '### Process' subsection (matching CLAUDE.md)"
+
+assert_contains "$TEMPLATE" "### Rules" \
+  "T22: Template has '### Rules' subsection (matching CLAUDE.md)"
+
+assert_contains "$TEMPLATE" "When ambiguity or disagreement arises" \
+  "T23: Template has matching intro text"
+
+assert_contains "$TEMPLATE" "Check against actual files/data" \
+  "T24: Template VERIFY step matches CLAUDE.md wording"
+
+assert_contains "$TEMPLATE" "Form judgment with evidence" \
+  "T25: Template EVALUATE step matches CLAUDE.md wording"
+
+echo ""
+
+# --- AC6: No other files modified ---
+echo "--- AC6: Only CLAUDE.md.template should be modified ---"
+echo "  (This is a git diff check — verified at PR time, not in this test)"
+echo "  SKIP: AC6 verified via git diff during review"
+
+echo ""
+
+# --- Summary ---
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- CLAUDE.md.template의 약한 Discussion Protocol (Raise/Context/Options/Recommend/Escalate 5단계)을 CLAUDE.md에 이미 존재하는 증거 기반 프로토콜 (UNDERSTAND/VERIFY/EVALUATE/RESPOND 4단계)로 교체
- 3가지 강제 규칙 추가: 근거 없는 동의 금지, 첫 교환 시 반론 의무, 코드 확인 없는 평가 금지
- 25개 테스트 케이스 포함 (all PASS)

## Test plan

- [x] 25개 테스트 모두 통과 확인 (`bash tests/test-discussion-protocol.sh`)
- [ ] CLAUDE.md.template Discussion Protocol이 CLAUDE.md와 일치하는지 확인
- [ ] 기존 5단계 프로토콜이 완전히 제거되었는지 확인

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)