### PR TITLE
feat(#8): make check-autoflow-gate.sh score categories dynamic

### DIFF
--- a/.claude/hooks/check-autoflow-gate.sh
+++ b/.claude/hooks/check-autoflow-gate.sh
@@ -11,6 +11,7 @@
 #
 # Environment:
 #   CLAUDE_PROJECT_DIR — Root directory of the project (set by Claude Code)
+#   AUTO_FAIL_KEY      — Category key for auto-fail (default: consistency)
 #
 # Exit codes:
 #   0 — Gate passed, proceed
@@ -25,7 +26,8 @@ set -euo pipefail
 STATE_DIR="${CLAUDE_PROJECT_DIR:-.}/.autoflow-state"
 PASS_THRESHOLD="7.5"
 MIN_CATEGORY_SCORE=7
-SECURITY_AUTO_FAIL_THRESHOLD=3
+AUTO_FAIL_KEY="${AUTO_FAIL_KEY:-consistency}"
+AUTO_FAIL_THRESHOLD=3
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -38,11 +40,9 @@ log_warn()  { echo "[AutoFlow Gate] ⚠️  $*"; }
 # ---------------------------------------------------------------------------
 # Resolve current issue
 # ---------------------------------------------------------------------------
-# Expects a file: .autoflow-state/current-issue
-# Contents: issue number (e.g., "123")
 get_current_issue() {
   local issue_file="${STATE_DIR}/current-issue"
-  if [[ ! -f "$issue_file" ]]; then
+  if [ ! -f "$issue_file" ]; then
     log_warn "No current-issue file found at ${issue_file}"
     log_info "Skipping gate check (no active Auto-Flow session)"
     exit 0
@@ -53,12 +53,10 @@ get_current_issue() {
 # ---------------------------------------------------------------------------
 # Read STEP status for an issue
 # ---------------------------------------------------------------------------
-# Expects a file: .autoflow-state/<issue>/step
-# Contents: step number (e.g., "6")
 get_current_step() {
   local issue="$1"
   local step_file="${STATE_DIR}/${issue}/step"
-  if [[ ! -f "$step_file" ]]; then
+  if [ ! -f "$step_file" ]; then
     log_fail "No step file found for issue #${issue}"
     log_info "Expected: ${step_file}"
     exit 1
@@ -69,13 +67,121 @@ get_current_step() {
 # ---------------------------------------------------------------------------
 # Extract a score value from evaluation JSON
 # ---------------------------------------------------------------------------
-# Uses basic grep/sed — no jq dependency required
+# Handles both flat format ("key": 8) and structured format ("key": {"score": 8, "reason": "..."})
+# Uses POSIX grep/sed/awk only — no jq dependency
 extract_score() {
   local file="$1"
   local key="$2"
-  grep -o "\"${key}\"[[:space:]]*:[[:space:]]*[0-9.]*" "$file" \
-    | head -1 \
-    | grep -o '[0-9.]*$' || echo "0"
+
+  # Find the line containing "key": and extract the numeric score.
+  # Handles both flat ("key": 8) and structured ("key": {"score": 8, "reason": "..."}).
+  # Uses POSIX grep/sed/awk only — no jq.
+  local score
+  score=$(awk -v key="\"${key}\"" '
+    BEGIN { found = 0 }
+    $0 ~ key {
+      # Check if this line has "score": (structured, same line)
+      if (match($0, /"score"[[:space:]]*:[[:space:]]*[0-9][0-9.]*/)) {
+        s = substr($0, RSTART, RLENGTH)
+        # Extract number after the colon
+        match(s, /[0-9][0-9.]*$/)
+        print substr(s, RSTART, RLENGTH)
+        exit
+      }
+      # Check if this line has { (structured, score on next line)
+      if ($0 ~ /{/) {
+        found = 1
+        next
+      }
+      # Flat format: "key": N (no { on the line)
+      match($0, /:[[:space:]]*[0-9][0-9.]*/)
+      if (RSTART > 0) {
+        s = substr($0, RSTART, RLENGTH)
+        match(s, /[0-9][0-9.]*/)
+        print substr(s, RSTART, RLENGTH)
+        exit
+      }
+    }
+    found && /\"score\"/ {
+      match($0, /[0-9][0-9.]*/)
+      if (RSTART > 0) {
+        print substr($0, RSTART, RLENGTH)
+      }
+      exit
+    }
+    found && /}/ { found = 0 }
+  ' "$file")
+
+  if [ -n "$score" ]; then
+    echo "$score"
+  else
+    echo "0"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Get all score keys from the evaluation JSON dynamically
+# ---------------------------------------------------------------------------
+get_score_keys() {
+  local file="$1"
+  # Extract all top-level keys from the "scores" JSON object.
+  # Uses only POSIX awk — no GNU extensions.
+  # Strategy: find the "scores" line, count brace depth to track nested objects,
+  # and extract key names that are direct children of "scores".
+  awk '
+    BEGIN { in_scores = 0; depth = 0 }
+    /"scores"[[:space:]]*:/ {
+      in_scores = 1
+      # Count braces on this line to set initial depth
+      depth = 0
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "{") depth++
+        if (c == "}") depth--
+      }
+      next
+    }
+    in_scores {
+      # Count opening/closing braces to track when we leave the scores object
+      for (i = 1; i <= length($0); i++) {
+        c = substr($0, i, 1)
+        if (c == "{") depth++
+        if (c == "}") depth--
+      }
+      # Extract key names (but skip nested keys like "score", "reason")
+      if (match($0, /"[a-zA-Z_][a-zA-Z0-9_]*"[[:space:]]*:/)) {
+        s = substr($0, RSTART + 1, RLENGTH - 3)
+        gsub(/[[:space:]]*$/, "", s)
+        gsub(/"/, "", s)
+        if (s != "score" && s != "reason" && s != "scores") {
+          print s
+        }
+      }
+      if (depth <= 0) { in_scores = 0 }
+    }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Get weight for a category from weights.json or equal weight fallback
+# ---------------------------------------------------------------------------
+get_weight() {
+  local issue="$1"
+  local category="$2"
+  local num_categories="$3"
+  local weights_file="${STATE_DIR}/${issue}/weights.json"
+
+  if [ -f "$weights_file" ]; then
+    local w
+    w=$(grep "\"${category}\"" "$weights_file" | grep -o '[0-9][0-9.]*' | head -1)
+    if [ -n "$w" ]; then
+      echo "$w"
+      return
+    fi
+  fi
+
+  # Equal weight fallback: 1/N
+  awk "BEGIN { printf \"%.6f\", 1.0 / $num_categories }"
 }
 
 # ---------------------------------------------------------------------------
@@ -83,61 +189,88 @@ extract_score() {
 # ---------------------------------------------------------------------------
 # IMPORTANT: This function does NOT read the AI-generated "pass" field.
 # It calculates pass/fail independently from the raw scores.
-# Reason: AI self-reporting is unreliable — it may implicitly adjust
-# standards while scoring. The gate operates on numbers, not AI judgment.
-# See: docs/design-rationale.md (Decision 3)
 check_evaluation_pass() {
   local issue="$1"
   local eval_file="${STATE_DIR}/${issue}/evaluation.json"
 
-  if [[ ! -f "$eval_file" ]]; then
+  if [ ! -f "$eval_file" ]; then
     log_fail "No evaluation file found: ${eval_file}"
     return 1
   fi
 
-  # Extract individual category scores from the raw "scores" object
-  local correctness code_quality test_coverage security performance
-  correctness=$(extract_score "$eval_file" "correctness")
-  code_quality=$(extract_score "$eval_file" "code_quality")
-  test_coverage=$(extract_score "$eval_file" "test_coverage")
-  security=$(extract_score "$eval_file" "security")
-  performance=$(extract_score "$eval_file" "performance")
+  # Dynamically discover all score categories
+  local score_keys
+  score_keys=$(get_score_keys "$eval_file")
+  local num_categories
+  num_categories=$(echo "$score_keys" | wc -l | tr -d '[:space:]')
 
-  log_info "Scores — correctness:${correctness} code_quality:${code_quality} test_coverage:${test_coverage} security:${security} performance:${performance}"
-
-  # Calculate weighted average from raw scores (NOT using AI's "overall" field)
-  local calculated_overall
-  calculated_overall=$(awk "BEGIN { printf \"%.2f\", ($correctness * 0.30) + ($code_quality * 0.20) + ($test_coverage * 0.20) + ($security * 0.15) + ($performance * 0.15) }")
-
-  log_info "Calculated overall: ${calculated_overall} (threshold: ${PASS_THRESHOLD})"
-
-  # Check 1: Security auto-fail
-  local security_fail
-  security_fail=$(awk "BEGIN { print ($security <= $SECURITY_AUTO_FAIL_THRESHOLD) ? 1 : 0 }")
-  if [[ "$security_fail" -eq 1 ]]; then
-    log_fail "Security score: ${security} (<= ${SECURITY_AUTO_FAIL_THRESHOLD}) — AUTO-FAIL (mandatory rework)"
+  if [ "$num_categories" -eq 0 ]; then
+    log_fail "No score categories found in ${eval_file}"
     return 1
+  fi
+
+  # Build score list and display
+  local scores_display=""
+  local all_scores=""
+  local key score
+  for key in $score_keys; do
+    score=$(extract_score "$eval_file" "$key")
+    scores_display="${scores_display} ${key}:${score}"
+    all_scores="${all_scores} ${key}=${score}"
+  done
+
+  log_info "Scores —${scores_display}"
+
+  # Check 1: Auto-fail key
+  local auto_fail_score
+  auto_fail_score=$(extract_score "$eval_file" "$AUTO_FAIL_KEY")
+  if [ "$auto_fail_score" != "0" ]; then
+    local is_auto_fail
+    is_auto_fail=$(awk "BEGIN { print ($auto_fail_score <= $AUTO_FAIL_THRESHOLD) ? 1 : 0 }")
+    if [ "$is_auto_fail" -eq 1 ]; then
+      log_fail "${AUTO_FAIL_KEY} score: ${auto_fail_score} (<= ${AUTO_FAIL_THRESHOLD}) — AUTO-FAIL (mandatory rework)"
+      return 1
+    fi
   fi
 
   # Check 2: Individual category minimums
-  local min_fail
-  min_fail=$(awk "BEGIN {
-    min = $correctness
-    if ($code_quality < min) min = $code_quality
-    if ($test_coverage < min) min = $test_coverage
-    if ($security < min) min = $security
-    if ($performance < min) min = $performance
-    print (min < $MIN_CATEGORY_SCORE) ? 1 : 0
-  }")
-  if [[ "$min_fail" -eq 1 ]]; then
-    log_fail "One or more categories below minimum (${MIN_CATEGORY_SCORE}) — FAIL"
+  local has_min_fail=0
+  local failing_categories=""
+  for key in $score_keys; do
+    score=$(extract_score "$eval_file" "$key")
+    local below_min
+    below_min=$(awk "BEGIN { print ($score < $MIN_CATEGORY_SCORE) ? 1 : 0 }")
+    if [ "$below_min" -eq 1 ]; then
+      has_min_fail=1
+      failing_categories="${failing_categories} ${key}(${score})"
+    fi
+  done
+
+  if [ "$has_min_fail" -eq 1 ]; then
+    log_fail "Categories below minimum (${MIN_CATEGORY_SCORE}):${failing_categories} — FAIL"
     return 1
   fi
 
-  # Check 3: Overall weighted average
+  # Check 3: Weighted average
+  local weighted_sum="0"
+  local weight_sum="0"
+  for key in $score_keys; do
+    score=$(extract_score "$eval_file" "$key")
+    local w
+    w=$(get_weight "$issue" "$key" "$num_categories")
+    weighted_sum=$(awk "BEGIN { printf \"%.6f\", $weighted_sum + ($score * $w) }")
+    weight_sum=$(awk "BEGIN { printf \"%.6f\", $weight_sum + $w }")
+  done
+
+  # Normalize by total weight (in case weights don't sum to 1)
+  local calculated_overall
+  calculated_overall=$(awk "BEGIN { printf \"%.2f\", $weighted_sum / $weight_sum }")
+
+  log_info "Calculated overall: ${calculated_overall} (threshold: ${PASS_THRESHOLD})"
+
   local overall_pass
   overall_pass=$(awk "BEGIN { print ($calculated_overall >= $PASS_THRESHOLD) ? 1 : 0 }")
-  if [[ "$overall_pass" -eq 1 ]]; then
+  if [ "$overall_pass" -eq 1 ]; then
     log_pass "Evaluation: ${calculated_overall} (>= ${PASS_THRESHOLD}), all categories >= ${MIN_CATEGORY_SCORE} — PASS"
     return 0
   else
@@ -152,7 +285,7 @@ check_evaluation_pass() {
 check_delegation_exists() {
   local issue="$1"
   local delegation_file="${STATE_DIR}/${issue}/delegation.md"
-  if [[ ! -f "$delegation_file" ]]; then
+  if [ ! -f "$delegation_file" ]; then
     log_fail "delegation.md not found: ${delegation_file}"
     log_info "STEP 4 must produce delegation.md before proceeding"
     return 1
@@ -169,7 +302,7 @@ main() {
   local issue
   issue=$(get_current_issue)
 
-  if [[ -z "$issue" ]]; then
+  if [ -z "$issue" ]; then
     log_info "No active issue — skipping gate"
     exit 0
   fi

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -341,16 +341,16 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 | Category | Weight | What It Measures |
 |----------|--------|-----------------|
-| Correctness | 30% | Does it fulfill the requirements? |
-| Code Quality | 20% | Clean, readable, maintainable? |
+| Correctness | 25% | Does it fulfill the requirements? |
+| Quality | 20% | Clean, readable, maintainable? |
 | Test Coverage | 20% | Critical paths tested? |
-| Security | 15% | No new vulnerabilities? |
-| Performance | 15% | No regressions, reasonable efficiency? |
+| Consistency | 20% | Aligned with design-rationale.md principles? |
+| Documentation | 15% | Docs updated, links valid, examples accurate? |
 
 ### PASS / FAIL
 - **PASS**: Overall weighted score >= 7.5 AND no individual category below 7 → proceed to STEP 8
 - **FAIL**: Overall score < 7.5 OR any category below 7 → return to STEP 7 (or STEP 3 for major issues)
-- **AUTO-FAIL**: Security score <= 3 → STEP 4 (mandatory rework regardless of other scores)
+- **AUTO-FAIL**: Consistency score <= 3 → STEP 4 (mandatory rework regardless of other scores)
 
 ### Exit Criteria
 - Evaluation report saved to `.autoflow-state/<issue>/evaluation.json`
@@ -389,7 +389,7 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 - Description with summary of changes
 - Link to evaluation report
 - Test results summary
-- Security checklist confirmation
+- Consistency with design-rationale.md confirmed
 
 ### Exit Criteria
 - PR created and linked to issue
@@ -426,7 +426,7 @@ When a STEP fails, the flow regresses — or terminates:
 | STEP 5b↔5c cycle (tests fail) | → STEP 5b (max 3 round-trips) | Fix implementation or tests |
 | STEP 5d (refactor breaks tests) | Fix (max 2 attempts) | Keep pre-refactor state |
 | STEP 6 (score < 7.5) | → STEP 7 | Revision needed |
-| STEP 6 (security <= 3) | → STEP 4 | Mandatory major rework |
+| STEP 6 (consistency <= 3) | → STEP 4 | Mandatory major rework |
 | STEP 8 (CI fails) | → STEP 5a | Re-test |
 | STEP 9 (human rejects) | → STEP 7 | Address human feedback |
 

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -39,19 +39,19 @@ A change **passes** evaluation when ALL of the following are true:
 
 1. **Overall weighted score >= 7.5**
 2. **No individual category score below 7**
-3. **Security score is NOT <= 3** (auto-fail trigger)
+3. **Consistency score is NOT <= 3** (auto-fail trigger)
 
 If any condition is not met, the change **fails**.
 
 ### Why These Thresholds Are Strict
 
-Lenient criteria create a pattern of "scoring high on easy categories to raise the average while passing weak categories." The individual minimum threshold (>= 7) prevents this gaming. Security <= 3 triggers mandatory rework because security cannot be diluted by averaging — some items are non-negotiable.
+Lenient criteria create a pattern of "scoring high on easy categories to raise the average while passing weak categories." The individual minimum threshold (>= 7) prevents this gaming. Consistency <= 3 triggers mandatory rework because violating core design principles cannot be diluted by averaging — some items are non-negotiable.
 
 ### Auto-FAIL Rules
 
 | Condition | Result | Action |
 |-----------|--------|--------|
-| Security <= 3 | AUTO-FAIL | → STEP 4 (mandatory major rework) |
+| Consistency <= 3 | AUTO-FAIL | → STEP 4 (mandatory major rework) |
 | Any category < 7 | FAIL | → STEP 7 (revision) |
 | Overall < 7.5 | FAIL | → STEP 7 (revision) |
 
@@ -61,39 +61,47 @@ Lenient criteria create a pattern of "scoring high on easy categories to raise t
 
 | Category | Weight | Description |
 |----------|--------|-------------|
-| **Correctness** | 30% | Does the implementation fulfill all requirements from the issue? Does it handle edge cases? |
-| **Code Quality** | 20% | Is the code clean, readable, and maintainable? Does it follow project conventions? |
+| **Correctness** | 25% | Does the implementation fulfill all requirements from the issue? Does it handle edge cases? |
+| **Quality** | 20% | Is the code clean, readable, and maintainable? Does it follow project conventions? |
 | **Test Coverage** | 20% | Are critical paths tested? Are edge cases covered? Do tests actually validate behavior? |
-| **Security** | 15% | Are there any new vulnerabilities? Does it pass the security checklist? |
-| **Performance** | 15% | Are there any regressions? Is the approach reasonably efficient? |
+| **Consistency** | 20% | Does the change align with design-rationale.md principles? Does it follow established patterns? |
+| **Documentation** | 15% | Are docs updated, links valid, examples accurate? |
+
+### Why "Consistency" Replaces "Security"
+
+This is a template project. The critical risk is not security vulnerabilities but **violating core design principles** (e.g., giving AI-A the issue content "for efficiency"). Consistency scoring catches this. Consistency <= 3 triggers AUTO-FAIL because undermining a core principle from design-rationale.md requires mandatory rework regardless of other scores.
 
 ### Weighted Score Calculation
 
+The gate hook dynamically reads all categories from the `scores` object and calculates the weighted average. If a `weights.json` file exists for the issue, those weights are used. Otherwise, equal weights (1/N) are applied across all categories.
+
 ```
-overall = (correctness * 0.30) + (code_quality * 0.20) + (test_coverage * 0.20) 
-        + (security * 0.15) + (performance * 0.15)
+Example with default CLAUDE.md weights (via weights.json):
+
+overall = (correctness * 0.25) + (quality * 0.20) + (test_coverage * 0.20) 
+        + (consistency * 0.20) + (documentation * 0.15)
 ```
 
 ### Example
 
 ```
-correctness:    8 * 0.30 = 2.40
-code_quality:   8 * 0.20 = 1.60
+correctness:    8 * 0.25 = 2.00
+quality:        8 * 0.20 = 1.60
 test_coverage:  7 * 0.20 = 1.40
-security:       9 * 0.15 = 1.35
-performance:    7 * 0.15 = 1.05
+consistency:    9 * 0.20 = 1.80
+documentation:  8 * 0.15 = 1.20
                          ------
-overall:                   7.80  → PASS (>= 7.5, all categories >= 7)
+overall:                   8.00  → PASS (>= 7.5, all categories >= 7)
 ```
 
 ```
-correctness:    9 * 0.30 = 2.70
-code_quality:   8 * 0.20 = 1.60
+correctness:    9 * 0.25 = 2.25
+quality:        8 * 0.20 = 1.60
 test_coverage:  6 * 0.20 = 1.20    ← below 7!
-security:       8 * 0.15 = 1.20
-performance:    8 * 0.15 = 1.20
+consistency:    8 * 0.20 = 1.60
+documentation:  8 * 0.15 = 1.20
                          ------
-overall:                   7.90  → FAIL (test_coverage 6 < minimum 7)
+overall:                   7.85  → FAIL (test_coverage 6 < minimum 7)
 ```
 
 ---
@@ -109,20 +117,11 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
   "evaluator": "evaluation-ai",
   "timestamp": "2025-01-15T10:30:00Z",
   "scores": {
-    "correctness": 8,
-    "code_quality": 7,
-    "test_coverage": 7,
-    "security": 9,
-    "performance": 7
-  },
-  "overall": 7.6,
-  "pass": true,
-  "category_feedback": {
-    "correctness": "All requirements met. Edge case for empty input handled correctly.",
-    "code_quality": "Clean implementation. Consider extracting the validation logic into a helper.",
-    "test_coverage": "Good coverage of happy path. Add a test for concurrent access.",
-    "security": "No issues found. Input validation is thorough.",
-    "performance": "Acceptable. The N+1 query in line 45 could be optimized but is not critical."
+    "correctness": { "score": 8, "reason": "All requirements met. Edge case for empty input handled correctly." },
+    "quality": { "score": 7, "reason": "Clean implementation. Consider extracting the validation logic into a helper." },
+    "test_coverage": { "score": 7, "reason": "Good coverage of happy path. Add a test for concurrent access." },
+    "consistency": { "score": 9, "reason": "Aligned with design-rationale.md principles throughout." },
+    "documentation": { "score": 7, "reason": "Docs updated. Internal links valid." }
   },
   "blocking_issues": [],
   "suggestions": [
@@ -140,12 +139,11 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
 | `issue` | string | Issue reference (e.g., "#123") |
 | `evaluator` | string | Agent identifier |
 | `timestamp` | string | ISO 8601 timestamp |
-| `scores` | object | Per-category scores (1–10) |
-| `overall` | number | Weighted average score |
-| `pass` | boolean | Whether criteria are met |
-| `category_feedback` | object | Per-category comments |
+| `scores` | object | Per-category scores — structured format with `score` and `reason` |
 | `blocking_issues` | array | Issues that must be fixed (empty if pass) |
 | `suggestions` | array | Non-blocking improvement ideas |
+
+> **Note**: The hook does NOT read any AI-generated `pass` or `overall` fields. It calculates pass/fail independently from the raw `scores` values. Flat format (`"key": N`) is also supported for backward compatibility.
 
 ---
 
@@ -158,7 +156,6 @@ The Evaluation AI receives:
 2. **Implementation plan** (`.autoflow-state/<issue>/plan.md`)
 3. **Code diff** (`git diff` of the changes)
 4. **Test results** (test output from STEP 5c)
-5. **Security checklist** (from `docs/security-checklist.md`)
 
 ### Evaluation Steps
 
@@ -166,8 +163,8 @@ The Evaluation AI receives:
 2. **Verify correctness** against requirements
 3. **Review code quality** against project conventions
 4. **Assess test coverage** — are critical paths tested?
-5. **Check security** against the security checklist
-6. **Evaluate performance** — any regressions or inefficiencies?
+5. **Check consistency** against design-rationale.md principles
+6. **Evaluate documentation** — are docs updated, links valid?
 7. **Score** each category
 8. **Calculate** weighted overall score
 9. **Determine** PASS/FAIL
@@ -198,9 +195,11 @@ When a change fails and goes through STEP 7 (revision):
 
 The `check-autoflow-gate.sh` hook enforces the gate by **calculating pass/fail independently from raw scores**:
 
-- The hook **does NOT read the AI-generated `pass` field**
-- It extracts individual scores from the `scores` object and calculates the weighted average itself
-- It checks: weighted average >= 7.5, all categories >= 7, security > 3
+- The hook **does NOT read the AI-generated `pass` or `overall` fields**
+- It dynamically discovers all keys in the `scores` object (no hardcoded category names)
+- It extracts individual scores, handling both flat (`"key": N`) and structured (`"key": {"score": N, "reason": "..."}`) formats
+- It reads weights from `.autoflow-state/<issue>/weights.json` if available, otherwise uses equal weights (1/N)
+- It checks: weighted average >= 7.5, all categories >= 7, auto-fail key > 3
 - This design brings the trust chain down to the script level — AI judgment is bypassed
 
 > **Why?** AI tends to implicitly adjust standards while scoring, or interpret edge cases favorably. The hook ignores AI judgment and checks only numbers. See [docs/design-rationale.md](design-rationale.md#decision-3-the-hook-does-not-trust-ais-pass-judgment).
@@ -209,24 +208,55 @@ The `check-autoflow-gate.sh` hook enforces the gate by **calculating pass/fail i
 
 ## Customizing the Evaluation System
 
-### Adjusting Weights
+### Dynamic Category Support
 
-Modify the category weights in `CLAUDE.md` to match your project priorities:
-- **Security-critical project**: Increase security weight to 25%, reduce performance to 5%
-- **Performance-critical project**: Increase performance weight to 25%, reduce code quality to 10%
+The gate hook dynamically enumerates all keys in the `scores` object. You are not limited to the default five categories — any category names work, as long as they appear in the evaluation JSON.
+
+### Configuring Weights
+
+Create a `weights.json` file in `.autoflow-state/<issue>/` to configure per-category weights:
+
+```json
+{
+  "correctness": 0.25,
+  "quality": 0.20,
+  "test_coverage": 0.20,
+  "consistency": 0.20,
+  "documentation": 0.15
+}
+```
+
+Without `weights.json`, all categories receive equal weight (1/N where N is the number of categories).
 
 ### Adjusting PASS Threshold
 
-The default thresholds are: overall >= 7.5, individual >= 7, security auto-fail <= 3. To change:
-1. Update `PASS_THRESHOLD`, `MIN_CATEGORY_SCORE`, and `SECURITY_AUTO_FAIL_THRESHOLD` in `check-autoflow-gate.sh`
+The default thresholds are: overall >= 7.5, individual >= 7, auto-fail key <= 3. To change:
+1. Update `PASS_THRESHOLD`, `MIN_CATEGORY_SCORE`, and `AUTO_FAIL_THRESHOLD` in `check-autoflow-gate.sh`
 2. Update the PASS criteria in `CLAUDE.md`
 3. Document the change and rationale
 
-### Adding Categories
+### Configuring the Auto-Fail Key
 
-You can add project-specific evaluation categories:
-- **Accessibility** (for frontend projects)
-- **Documentation** (for API projects)
-- **Backwards Compatibility** (for library projects)
+The auto-fail key defaults to `consistency`. To change it, set the `AUTO_FAIL_KEY` environment variable:
 
-Update the weights so all categories sum to 100%.
+```bash
+AUTO_FAIL_KEY=security bash .claude/hooks/check-autoflow-gate.sh
+```
+
+If the configured auto-fail key does not exist in the evaluation scores, no auto-fail check is performed.
+
+### Adding Custom Categories
+
+Add any category to the evaluation JSON — the hook discovers them automatically. For example, a frontend project might use:
+
+```json
+{
+  "scores": {
+    "correctness": { "score": 8, "reason": "Requirements met" },
+    "accessibility": { "score": 9, "reason": "WCAG AA compliant" },
+    "performance": { "score": 7, "reason": "Lighthouse score acceptable" }
+  }
+}
+```
+
+Update `weights.json` to assign appropriate weights to your custom categories. If weights are omitted, all categories are weighted equally.

--- a/tests/test-check-autoflow-gate.sh
+++ b/tests/test-check-autoflow-gate.sh
@@ -1,0 +1,829 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: Dynamic Score Categories for check-autoflow-gate.sh (Issue #8)
+# =============================================================================
+# Validates that the gate hook dynamically enumerates score categories,
+# supports dual formats (flat/structured), handles weight configuration,
+# and allows configurable auto-fail keys.
+#
+# All tests create temporary directories with mock .autoflow-state/ fixtures
+# and invoke the hook script, checking exit codes and output.
+# =============================================================================
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+HOOK=".claude/hooks/check-autoflow-gate.sh"
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+assert_exit_code() {
+  local expected="$1" actual="$2" desc="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (expected exit $expected, got $actual)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_output_contains() {
+  local output_file="$1" pattern="$2" desc="$3"
+  if grep -qi "$pattern" "$output_file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' not found in output)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_output_not_contains() {
+  local output_file="$1" pattern="$2" desc="$3"
+  if grep -qi "$pattern" "$output_file" 2>/dev/null; then
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' unexpectedly found in output)")
+    echo "  FAIL: $desc"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+TEST_DIR=""
+
+setup_test_dir() {
+  TEST_DIR=$(mktemp -d)
+}
+
+cleanup_test_dir() {
+  if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+}
+
+# Set up mock autoflow-state with a given step and evaluation JSON
+setup_eval_fixture() {
+  local step="$1"
+  local eval_json="$2"
+  local issue="99"
+  mkdir -p "${TEST_DIR}/.autoflow-state/${issue}"
+  echo "$issue" > "${TEST_DIR}/.autoflow-state/current-issue"
+  echo "$step" > "${TEST_DIR}/.autoflow-state/${issue}/step"
+  # Create delegation.md so delegation gate doesn't block
+  cat > "${TEST_DIR}/.autoflow-state/${issue}/delegation.md" <<'EOF'
+## Team
+test-team
+## Test AI Instructions
+test
+## Developer AI Instructions
+test
+EOF
+  echo "$eval_json" > "${TEST_DIR}/.autoflow-state/${issue}/evaluation.json"
+}
+
+# Run hook and capture exit code + output
+run_hook() {
+  local exit_code=0
+  CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output.txt" 2>&1 || exit_code=$?
+  echo "$exit_code"
+}
+
+# Run hook with custom env vars
+run_hook_with_env() {
+  local env_vars="$1"
+  local exit_code=0
+  eval "$env_vars CLAUDE_PROJECT_DIR=\"$TEST_DIR\" bash \"$HOOK\"" > "${TEST_DIR}/output.txt" 2>&1 || exit_code=$?
+  echo "$exit_code"
+}
+
+echo "=== Test Suite: Dynamic Score Categories (Issue #8) ==="
+echo ""
+
+# ==========================================================================
+# GROUP 1: Dynamic Enumeration — Standard Categories
+# ==========================================================================
+echo "--- GROUP 1: Dynamic enumeration with standard CLAUDE.md categories ---"
+
+setup_test_dir
+setup_eval_fixture 6 '{
+  "step": 6,
+  "issue": "#99",
+  "scores": {
+    "correctness": { "score": 9, "reason": "Meets all requirements" },
+    "quality": { "score": 8, "reason": "Clean code" },
+    "test_coverage": { "score": 8, "reason": "Good coverage" },
+    "consistency": { "score": 9, "reason": "Aligned with design" },
+    "documentation": { "score": 8, "reason": "Docs updated" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T01: Standard CLAUDE.md categories (all passing) → PASS"
+assert_output_contains "${TEST_DIR}/output.txt" "PASS" \
+  "T02: Output indicates PASS for standard categories"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 2: Dynamic Enumeration — Custom/Arbitrary Categories
+# ==========================================================================
+echo "--- GROUP 2: Dynamic enumeration with custom categories ---"
+
+setup_test_dir
+setup_eval_fixture 6 '{
+  "step": 6,
+  "issue": "#99",
+  "scores": {
+    "accessibility": { "score": 9, "reason": "WCAG compliant" },
+    "reliability": { "score": 8, "reason": "Error handling solid" },
+    "maintainability": { "score": 8, "reason": "Well structured" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T03: Custom categories (accessibility, reliability, maintainability) → PASS"
+assert_output_contains "${TEST_DIR}/output.txt" "accessibility\|reliability\|maintainability" \
+  "T04: Output mentions custom category names"
+cleanup_test_dir
+
+echo ""
+
+# Test with a single category
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "overall_quality": { "score": 9, "reason": "Excellent" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T05: Single custom category with high score → PASS"
+cleanup_test_dir
+
+echo ""
+
+# Test with many categories
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_a": 8,
+    "cat_b": 8,
+    "cat_c": 8,
+    "cat_d": 8,
+    "cat_e": 8,
+    "cat_f": 8,
+    "cat_g": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T06: Seven flat-format custom categories all passing → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 3: Dual Format Support — Flat
+# ==========================================================================
+echo "--- GROUP 3: Dual format — flat ---"
+
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 9,
+    "quality": 8,
+    "test_coverage": 8,
+    "consistency": 9,
+    "documentation": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T07: Flat format scores (all passing) → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 4: Dual Format Support — Structured
+# ==========================================================================
+echo "--- GROUP 4: Dual format — structured ---"
+
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": { "score": 9, "reason": "All requirements met" },
+    "quality": { "score": 8, "reason": "Clean" },
+    "test_coverage": { "score": 8, "reason": "Covered" },
+    "consistency": { "score": 9, "reason": "Consistent" },
+    "documentation": { "score": 8, "reason": "Updated" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T08: Structured format scores (all passing) → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 5: Dual Format Support — Mixed
+# ==========================================================================
+echo "--- GROUP 5: Dual format — mixed ---"
+
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 9,
+    "quality": { "score": 8, "reason": "Clean code" },
+    "test_coverage": 8,
+    "consistency": { "score": 9, "reason": "Aligned" },
+    "documentation": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T09: Mixed format (flat + structured) all passing → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 6: Weight Configuration — With weights.json
+# ==========================================================================
+echo "--- GROUP 6: Weight configuration with weights.json ---"
+
+# With weights.json: weighted average should use configured weights
+# correctness=10 (weight 0.5), quality=6 (weight 0.5) → avg = 8.0 → PASS
+# BUT quality=6 < 7 → FAIL due to individual minimum
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 6
+  }
+}'
+cat > "${TEST_DIR}/.autoflow-state/99/weights.json" <<'WJSON'
+{
+  "correctness": 0.5,
+  "quality": 0.5
+}
+WJSON
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T10: With weights.json, quality=6 below min → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# With weights.json: heavy weight on high-scoring category pulls average up
+# correctness=10 (weight 0.9), quality=7 (weight 0.1) → weighted avg = 9.7 → PASS
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 7
+  }
+}'
+cat > "${TEST_DIR}/.autoflow-state/99/weights.json" <<'WJSON'
+{
+  "correctness": 0.9,
+  "quality": 0.1
+}
+WJSON
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T11: With weights.json, weighted avg=9.7, all>=7 → PASS"
+cleanup_test_dir
+
+echo ""
+
+# Verify weights actually matter: same scores, different weights, different result
+# correctness=7 (weight 0.1), quality=10 (weight 0.9) → weighted avg = 9.7 → PASS
+# correctness=7 (weight 0.9), quality=10 (weight 0.1) → weighted avg = 7.3 → FAIL (<7.5)
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 7,
+    "quality": 10
+  }
+}'
+cat > "${TEST_DIR}/.autoflow-state/99/weights.json" <<'WJSON'
+{
+  "correctness": 0.9,
+  "quality": 0.1
+}
+WJSON
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T12: With weights.json, heavy weight on low score → weighted avg<7.5 → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 7: Weight Configuration — Without weights.json (equal weights)
+# ==========================================================================
+echo "--- GROUP 7: Without weights.json → equal weights ---"
+
+# 3 categories at 8 each → avg = 8.0 → PASS
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_x": 8,
+    "cat_y": 8,
+    "cat_z": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T13: No weights.json, 3 categories at 8 → equal avg=8.0 → PASS"
+cleanup_test_dir
+
+echo ""
+
+# 2 categories: one at 10, one at 7 → equal avg = 8.5 → PASS (both >= 7)
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "alpha": 10,
+    "beta": 7
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T14: No weights.json, avg=8.5, all>=7 → PASS"
+cleanup_test_dir
+
+echo ""
+
+# 2 categories: one at 10, one at 5 → equal avg = 7.5 → but 5 < 7 → FAIL
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "alpha": 10,
+    "beta": 5
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T15: No weights.json, avg=7.5 but beta=5<7 → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 8: Auto-Fail — Default Key (consistency)
+# ==========================================================================
+echo "--- GROUP 8: Auto-fail with default key (consistency) ---"
+
+# consistency <= 3 → AUTO-FAIL regardless of other scores
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 10,
+    "test_coverage": 10,
+    "consistency": 3,
+    "documentation": 10
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T16: consistency=3 (<=3) → AUTO-FAIL"
+assert_output_contains "${TEST_DIR}/output.txt" "AUTO.FAIL\|auto.fail" \
+  "T17: Output mentions AUTO-FAIL for consistency<=3"
+cleanup_test_dir
+
+echo ""
+
+# consistency = 2 → AUTO-FAIL
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 10,
+    "test_coverage": 10,
+    "consistency": 2,
+    "documentation": 10
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T18: consistency=2 → AUTO-FAIL"
+cleanup_test_dir
+
+echo ""
+
+# consistency = 4 → NOT auto-fail (but still below 7, so FAIL for min check)
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 10,
+    "test_coverage": 10,
+    "consistency": 4,
+    "documentation": 10
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T19: consistency=4 → not auto-fail, but <7 → FAIL (min check)"
+assert_output_not_contains "${TEST_DIR}/output.txt" "AUTO.FAIL\|auto.fail" \
+  "T20: consistency=4 does NOT trigger AUTO-FAIL message"
+cleanup_test_dir
+
+echo ""
+
+# consistency = 8 → no auto-fail, passes fine
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 8,
+    "quality": 8,
+    "test_coverage": 8,
+    "consistency": 8,
+    "documentation": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T21: consistency=8 → no auto-fail, all pass → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 9: Auto-Fail — Custom AUTO_FAIL_KEY env var
+# ==========================================================================
+echo "--- GROUP 9: Custom AUTO_FAIL_KEY ---"
+
+# Custom auto-fail key: "reliability" at <=3 → AUTO-FAIL
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "reliability": 3,
+    "quality": 10
+  }
+}'
+exit_code=$(run_hook_with_env "AUTO_FAIL_KEY=reliability")
+assert_exit_code 1 "$exit_code" \
+  "T22: AUTO_FAIL_KEY=reliability, reliability=3 → AUTO-FAIL"
+assert_output_contains "${TEST_DIR}/output.txt" "AUTO.FAIL\|auto.fail" \
+  "T23: Output mentions AUTO-FAIL for custom key"
+cleanup_test_dir
+
+echo ""
+
+# Custom auto-fail key: consistency is no longer the auto-fail key
+# So consistency=2 does NOT trigger auto-fail (but still fails min check)
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "consistency": 2,
+    "quality": 10
+  }
+}'
+exit_code=$(run_hook_with_env "AUTO_FAIL_KEY=reliability")
+assert_exit_code 1 "$exit_code" \
+  "T24: AUTO_FAIL_KEY=reliability, consistency=2 → no auto-fail (fails min check)"
+assert_output_not_contains "${TEST_DIR}/output.txt" "AUTO.FAIL\|auto.fail" \
+  "T25: No AUTO-FAIL message when key doesn't match"
+cleanup_test_dir
+
+echo ""
+
+# Non-existent auto-fail key → no auto-fail triggered at all
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 8,
+    "quality": 8,
+    "test_coverage": 8
+  }
+}'
+exit_code=$(run_hook_with_env "AUTO_FAIL_KEY=nonexistent_key")
+assert_exit_code 0 "$exit_code" \
+  "T26: AUTO_FAIL_KEY=nonexistent_key → no auto-fail, scores pass → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 10: Pass/Fail Calculation — Edge Cases
+# ==========================================================================
+echo "--- GROUP 10: Pass/fail edge cases ---"
+
+# All scores exactly 7.5 → avg=7.5, all>=7 → PASS
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_a": 7.5,
+    "cat_b": 7.5,
+    "cat_c": 7.5
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T27: All categories at 7.5 → avg=7.5, all>=7 → PASS"
+cleanup_test_dir
+
+echo ""
+
+# One category at exactly 7, rest at 8 → avg=7.75, all>=7 → PASS
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_a": 8,
+    "cat_b": 7,
+    "cat_c": 8,
+    "cat_d": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T28: One category at 7, rest at 8 → avg=7.75, all>=7 → PASS"
+cleanup_test_dir
+
+echo ""
+
+# One category at 6.9 → below individual minimum → FAIL
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_a": 9,
+    "cat_b": 6.9,
+    "cat_c": 9
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T29: One category at 6.9 (<7) → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# Average exactly 7.49 → below threshold → FAIL
+# 3 categories: 7, 7, 7.47 → avg ≈ 7.157 → FAIL
+# Better: 2 categories: 7, 7.98 → avg = 7.49 → FAIL
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "cat_a": 7,
+    "cat_b": 7.98
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T30: Average=7.49 (below 7.5 threshold) → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# All perfect 10s → PASS
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 10,
+    "quality": 10,
+    "test_coverage": 10,
+    "consistency": 10,
+    "documentation": 10
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T31: All perfect 10s → PASS"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 11: Backward Compatibility — Old Format
+# ==========================================================================
+echo "--- GROUP 11: Backward compatibility with old flat format ---"
+
+# The old hardcoded categories in flat format should still work
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 9,
+    "code_quality": 8,
+    "test_coverage": 8,
+    "security": 9,
+    "performance": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T32: Old flat format with original category names → PASS"
+cleanup_test_dir
+
+echo ""
+
+# Old format with failing security → should be AUTO-FAIL if consistency is default
+# NOTE: In the NEW system, auto-fail key defaults to "consistency", not "security"
+# So old-style "security" at 2 should NOT trigger auto-fail (but fails min check)
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": 9,
+    "code_quality": 8,
+    "test_coverage": 8,
+    "security": 2,
+    "performance": 8
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T33: Old format, security=2 → FAIL (min check, not auto-fail since key is consistency)"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 12: No jq Dependency
+# ==========================================================================
+echo "--- GROUP 12: No jq dependency ---"
+
+# Verify the script doesn't invoke jq as a command (comments don't count)
+# Strip comments, then check for jq usage
+if sed 's/#.*//' "$HOOK" | grep -q '\bjq\b' 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T34: Script contains jq dependency in executable code")
+  echo "  FAIL: T34: Script does not use jq in executable code"
+else
+  PASS=$((PASS + 1))
+  echo "  PASS: T34: Script does not use jq in executable code"
+fi
+
+echo ""
+
+# ==========================================================================
+# GROUP 13: Dynamic Key Enumeration Function Exists
+# ==========================================================================
+echo "--- GROUP 13: Dynamic key enumeration ---"
+
+# The script should have a function or mechanism for dynamic key discovery
+# (not hardcoded category variable names)
+if grep -q 'get_score_keys\|score_keys\|for.*key.*in.*scores\|for.*category' "$HOOK" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: T35: Script has dynamic key enumeration mechanism"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T35: Script lacks dynamic key enumeration (still hardcoded)")
+  echo "  FAIL: T35: Script has dynamic key enumeration mechanism"
+fi
+
+echo ""
+
+# The script should NOT have hardcoded category assignments like the current version
+# (correctness=, code_quality=, test_coverage=, security=, performance=)
+if grep -q 'correctness=.*extract_score.*correctness' "$HOOK" 2>/dev/null; then
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T36: Script still has hardcoded category extraction")
+  echo "  FAIL: T36: Script does NOT have hardcoded category extraction"
+else
+  PASS=$((PASS + 1))
+  echo "  PASS: T36: Script does NOT have hardcoded category extraction"
+fi
+
+echo ""
+
+# ==========================================================================
+# GROUP 14: Weight Function Exists
+# ==========================================================================
+echo "--- GROUP 14: Weight configuration function ---"
+
+# Script should have weight configuration logic (reading weights.json, get_weight function)
+# Checking for actual function/file-reading logic, not just "weight" in comments
+if grep -q 'weights\.json\|get_weight' "$HOOK" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: T37: Script has weight configuration support (weights.json or get_weight)"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T37: Script lacks weight configuration support (no weights.json or get_weight)")
+  echo "  FAIL: T37: Script has weight configuration support (weights.json or get_weight)"
+fi
+
+echo ""
+
+# ==========================================================================
+# GROUP 15: Auto-Fail Key Configuration
+# ==========================================================================
+echo "--- GROUP 15: Auto-fail key is configurable ---"
+
+# Script should reference AUTO_FAIL_KEY or similar configurable mechanism
+if grep -q 'AUTO_FAIL_KEY\|auto_fail_key' "$HOOK" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: T38: Script has configurable auto-fail key"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T38: Script lacks configurable auto-fail key (hardcoded to security)")
+  echo "  FAIL: T38: Script has configurable auto-fail key"
+fi
+
+echo ""
+
+# Script should default auto-fail key to "consistency" (not "security")
+if grep -q 'consistency' "$HOOK" 2>/dev/null && grep -q 'AUTO_FAIL_KEY\|auto_fail_key' "$HOOK" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: T39: Auto-fail key defaults to consistency"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: T39: Auto-fail key does not default to consistency")
+  echo "  FAIL: T39: Auto-fail key defaults to consistency"
+fi
+
+echo ""
+
+# ==========================================================================
+# GROUP 16: STEP 8 also uses dynamic evaluation
+# ==========================================================================
+echo "--- GROUP 16: STEP 8 uses same dynamic evaluation ---"
+
+setup_test_dir
+setup_eval_fixture 8 '{
+  "scores": {
+    "custom_a": { "score": 9, "reason": "Good" },
+    "custom_b": { "score": 8, "reason": "Fine" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 0 "$exit_code" \
+  "T40: STEP 8 with custom categories → PASS"
+cleanup_test_dir
+
+echo ""
+
+setup_test_dir
+setup_eval_fixture 8 '{
+  "scores": {
+    "custom_a": { "score": 9, "reason": "Good" },
+    "custom_b": { "score": 5, "reason": "Poor" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T41: STEP 8 with one low custom category → FAIL"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# GROUP 17: Structured format score extraction
+# ==========================================================================
+echo "--- GROUP 17: extract_score handles structured format ---"
+
+# Structured format with "score" key nested inside an object
+setup_test_dir
+setup_eval_fixture 6 '{
+  "scores": {
+    "correctness": { "score": 5, "reason": "Incomplete implementation" },
+    "quality": { "score": 5, "reason": "Messy" },
+    "test_coverage": { "score": 5, "reason": "Sparse" },
+    "consistency": { "score": 5, "reason": "Misaligned" },
+    "documentation": { "score": 5, "reason": "Missing" }
+  }
+}'
+exit_code=$(run_hook)
+assert_exit_code 1 "$exit_code" \
+  "T42: All structured scores at 5 → FAIL (below min)"
+cleanup_test_dir
+
+echo ""
+
+# ==========================================================================
+# Summary
+# ==========================================================================
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Replace hardcoded evaluation categories in `check-autoflow-gate.sh` with dynamic key enumeration from JSON `scores` object
- Add configurable weight system via optional `weights.json` (falls back to equal weights)
- Make auto-fail key configurable via `AUTO_FAIL_KEY` env var (default: `consistency`)
- Support both flat (`"key": 8`) and structured (`"key": {"score": 8, "reason": "..."}`) score formats
- Align `docs/evaluation-system.md` and `docs/autoflow-guide.md` with CLAUDE.md categories (Correctness 25%, Quality 20%, Test Coverage 20%, Consistency 20%, Documentation 15%)

Closes #8

## Test plan

- [x] 42 shell script tests covering all acceptance criteria
- [ ] Verify dynamic enumeration with standard and custom categories
- [ ] Verify dual format support (flat, structured, mixed)
- [ ] Verify weight configuration (with/without weights.json)
- [ ] Verify configurable auto-fail key
- [ ] Verify pass/fail edge cases
- [ ] Verify backward compatibility with old format
- [ ] Verify cross-platform (macOS + Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)