### PR TITLE
chore: integrate /simplify into STEP 5d

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,14 +366,17 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** st
 ### STEP 5d: Refactor
 
 ```
-5d-1. Refactoring needed?
-      ├─ Yes → code cleanup (no behavior change) → 5d-2
-      └─ No  → document reason ("no cleanup needed") → 5d-2 (DO NOT SKIP)
+5d-1. Developer AI teammate runs /simplify
+      - Automatically analyzes reuse, quality, and efficiency (3 parallel agents)
+      - Applies suggested fixes (no behavior change — tests must pass without modification)
+      - If /simplify finds nothing → proceed to 5d-2 (DO NOT SKIP)
 5d-2. [MUST] Re-run ALL tests → Green maintained
-      - This step is NEVER skipped, even when 5d-1 found nothing to refactor
-      - FAIL → refactor broke something → fix (max 2 attempts, then keep pre-refactor state)
+      - This step is NEVER skipped, even when 5d-1 made no changes
+      - FAIL → simplify broke something → revert simplify changes (max 2 attempts, then keep pre-refactor state)
 5d-3. Commit (refactor type, or skip commit if no changes in 5d-1)
 ```
+
+**Why /simplify instead of manual judgment?** Previously, the Developer AI decided "refactoring needed?" — but this judgment was routinely skipped with "no cleanup needed." `/simplify` removes this bias by mechanically analyzing the code. The AI no longer decides IF to refactor; a dedicated tool decides WHAT to refactor.
 
 **[MUST]** 5d-2 is mandatory. "No changes were made so tests will pass" is not a valid reason to skip. The re-run confirms that no accidental state changes occurred between STEP 5c and 5d.
 


### PR DESCRIPTION
## Summary

- STEP 5d의 수동 리팩토링 판단을 `/simplify` 스킬 실행으로 교체
- teammate Agent에서 `/simplify` 실행 가능 확인 완료

## Why

Developer AI가 "리팩토링 불필요"로 스킵하는 편향을 제거. `/simplify`가 기계적으로 reuse/quality/efficiency를 분석하므로 AI의 판단 개입 없음.

## Test plan

- [x] teammate Agent에서 /simplify 실행 테스트 완료
- [ ] 다음 이슈에서 STEP 5d /simplify 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)