### PR TITLE
refactor: rename STEP numbering to descriptive phase names

### DIFF
--- a/.claude/hooks/check-autoflow-gate.sh
+++ b/.claude/hooks/check-autoflow-gate.sh
@@ -2,12 +2,17 @@
 # =============================================================================
 # Auto-Flow Gate Hook
 # =============================================================================
-# Enforces Auto-Flow STEP progression by validating state files before
+# Enforces Auto-Flow phase progression by validating state files before
 # allowing commits or PR creation.
+#
+# Phase names (in order):
+#   PREFLIGHT → DIAGNOSE → GATE:HYPOTHESIS → ARCHITECT → GATE:PLAN →
+#   DISPATCH → RED → GREEN → VERIFY → REFINE → GATE:SECURITY →
+#   GATE:QUALITY → SHIP → LAND
 #
 # Usage:
 #   This script is called by Claude Code hooks. It checks .autoflow-state/
-#   files to ensure the current STEP's exit criteria are met.
+#   files to ensure the current phase's exit criteria are met.
 #
 # Environment:
 #   CLAUDE_PROJECT_DIR — Root directory of the project (set by Claude Code)
@@ -51,17 +56,17 @@ get_current_issue() {
 }
 
 # ---------------------------------------------------------------------------
-# Read STEP status for an issue
+# Read phase status for an issue
 # ---------------------------------------------------------------------------
-get_current_step() {
+get_current_phase() {
   local issue="$1"
-  local step_file="${STATE_DIR}/${issue}/step"
-  if [ ! -f "$step_file" ]; then
-    log_fail "No step file found for issue #${issue}"
-    log_info "Expected: ${step_file}"
+  local phase_file="${STATE_DIR}/${issue}/phase"
+  if [ ! -f "$phase_file" ]; then
+    log_fail "No phase file found for issue #${issue}"
+    log_info "Expected: ${phase_file}"
     exit 1
   fi
-  cat "$step_file" | tr -d '[:space:]'
+  cat "$phase_file" | tr -d '[:space:]'
 }
 
 # ---------------------------------------------------------------------------
@@ -287,7 +292,7 @@ check_delegation_exists() {
   local delegation_file="${STATE_DIR}/${issue}/delegation.md"
   if [ ! -f "$delegation_file" ]; then
     log_fail "delegation.md not found: ${delegation_file}"
-    log_info "STEP 4 must produce delegation.md before proceeding"
+    log_info "DISPATCH must produce delegation.md before proceeding"
     return 1
   fi
   return 0
@@ -309,47 +314,42 @@ main() {
 
   log_info "Active issue: #${issue}"
 
-  local step
-  step=$(get_current_step "$issue")
-  log_info "Current STEP: ${step}"
+  local phase
+  phase=$(get_current_phase "$issue")
+  log_info "Current phase: ${phase}"
 
-  case "$step" in
-    # Steps 0-4: No gate block — these are pre-evaluation steps
-    [0-4])
-      log_pass "STEP ${step} — no gate restrictions"
+  case "$phase" in
+    # Pre-evaluation phases: no gate block (DISPATCH creates delegation.md during this phase)
+    PREFLIGHT|DIAGNOSE|GATE:HYPOTHESIS|ARCHITECT|GATE:PLAN|DISPATCH)
+      log_pass "${phase} — no gate restrictions"
       ;;
 
-    # Step 5: Delegation gate — delegation.md must exist
-    5)
+    # TDD phases: delegation must exist
+    RED|GREEN|VERIFY|REFINE)
       check_delegation_exists "$issue" || exit 1
-      log_pass "STEP ${step} — delegation.md found"
+      log_pass "${phase} — delegation.md found, TDD in progress"
       ;;
 
-    # Step 6: Evaluation in progress — block commits until evaluation completes
-    6)
+    # Evaluation gates: check scores
+    GATE:SECURITY|GATE:QUALITY)
       check_delegation_exists "$issue" || exit 1
-      log_info "STEP 6 — checking evaluation result..."
+      log_info "${phase} — checking evaluation result..."
       check_evaluation_pass "$issue"
       ;;
 
-    # Step 7: Revision — allow commits (working on fixes)
-    7)
-      log_pass "STEP 7 (revision) — commits allowed"
-      ;;
-
-    # Step 8: PR phase — evaluation must have passed
-    8)
-      log_info "STEP 8 — verifying evaluation before PR..."
+    # SHIP: evaluation must have passed
+    SHIP)
+      log_info "${phase} — verifying evaluation before PR..."
       check_evaluation_pass "$issue"
       ;;
 
-    # Step 9: Merge phase — human action required
-    9)
-      log_warn "STEP 9 — waiting for human merge approval"
+    # LAND: human action required
+    LAND)
+      log_warn "${phase} — waiting for human merge approval"
       ;;
 
     *)
-      log_warn "Unknown STEP: ${step} — allowing by default"
+      log_warn "Unknown phase: ${phase} — allowing by default"
       ;;
   esac
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ A public template repository that generalizes the Auto-Flow methodology from `on
 |------|------|
 | `CLAUDE.md.template` | Core template users will generate CLAUDE.md from |
 | `docs/design-rationale.md` | Design philosophy — why every rule exists |
-| `docs/autoflow-guide.md` | Step-by-step Auto-Flow lifecycle |
+| `docs/autoflow-guide.md` | Phase-by-phase Auto-Flow lifecycle |
 | `.claude/hooks/check-autoflow-gate.sh` | Hook script enforcing evaluation gates |
 | `setup/init.sh` | Interactive project setup wizard |
 | `subrepo-templates/` | Sub-repo CLAUDE.md templates |
@@ -371,7 +371,7 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** ph
       - Applies suggested fixes (no behavior change — tests must pass without modification)
       - If /simplify finds nothing → proceed to 5d-2 (DO NOT SKIP)
 5d-2. [MUST] Re-run ALL tests → Green maintained
-      - This step is NEVER skipped, even when 5d-1 made no changes
+      - This phase is NEVER skipped, even when 5d-1 made no changes
       - FAIL → simplify broke something → revert simplify changes (max 2 attempts, then keep pre-refactor state)
 5d-3. Commit (refactor type, or skip commit if no changes in 5d-1)
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ All communication with the user must be in Korean. Code, documentation content, 
 
 ---
 
-## Auto-Flow Lifecycle (STEP 0-9)
+## Auto-Flow Lifecycle (PREFLIGHT → LAND)
 
 This project follows Auto-Flow with Agent Teams. Even though this is a single repo, **the orchestrator does not implement**. The orchestrator coordinates, and spawns teammates to do the actual work.
 
@@ -47,9 +47,9 @@ This project follows Auto-Flow with Agent Teams. Even though this is a single re
 | Role | How | Constraint |
 |------|-----|-----------|
 | **Orchestrator** | Main session (you) | Coordinates only — does NOT write code, tests, or templates |
-| **Test AI** | Teammate (`Agent` with `team_name`) | Writes tests from acceptance criteria (STEP 5a) |
-| **Developer AI** | Teammate (`Agent` with `team_name`) | Writes minimum code to pass tests (STEP 5b) |
-| **Evaluation AI** | Fresh `Agent` (no team, no history) | Scores work at STEPs 1.5, 3, 6 — **spawned fresh every time** |
+| **Test AI** | Teammate (`Agent` with `team_name`) | Writes tests from acceptance criteria (RED) |
+| **Developer AI** | Teammate (`Agent` with `team_name`) | Writes minimum code to pass tests (GREEN) |
+| **Evaluation AI** | Fresh `Agent` (no team, no history) | Scores work at GATE:HYPOTHESIS, GATE:PLAN, GATE:QUALITY — **spawned fresh every time** |
 
 ### Evaluation AI Prompt Rules
 
@@ -89,30 +89,30 @@ Orchestrator → Agent (fresh, no team)               : spawn Evaluation AI (ind
 
 All teammates work on the **same repository** (single repo — no submodule navigation needed).
 
-### STEP Definitions
+### Phase Definitions
 
 ```
-STEP 0: Pre-Work         → Git Clean Check, branch creation
-STEP 1: Issue Analysis    → 3-Phase independent analysis (bias prevention)
-STEP 1.5: Structure Eval  → Evaluation AI (fresh spawn): PASS → continue, FAIL → close issue
-STEP 2: Plan Synthesis    → Merge analyses into implementation plan + acceptance criteria
-STEP 3: Plan Evaluation   → Evaluation AI (fresh spawn): 5 categories × 10 points
-STEP 4: Task Assignment   → TeamCreate + SendMessage to Test AI and Developer AI
-STEP 5a: Test Writing     → Test AI writes tests → Red confirmation
-STEP 5b: Implementation   → Developer AI writes minimum code to pass tests
-STEP 5c: Green + Verify   → All tests pass + minimal implementation check
-STEP 5d: Refactor         → Developer AI code cleanup, Green re-confirmation
-STEP 6: Evaluation        → Evaluation AI (fresh spawn): scored quality assessment
-STEP 7: Revision          → Fix evaluation feedback (if STEP 6 FAIL)
-STEP 8: PR & Review       → Create PR for human review
-STEP 9: Merge & Close     → Human approves and merges
+PREFLIGHT:       Pre-Work         → Git Clean Check, branch creation
+DIAGNOSE:        Issue Analysis    → 3-Phase independent analysis (bias prevention)
+GATE:HYPOTHESIS: Structure Eval   → Evaluation AI (fresh spawn): PASS → continue, FAIL → close issue
+ARCHITECT:       Plan Synthesis    → Merge analyses into implementation plan + acceptance criteria
+GATE:PLAN:       Plan Evaluation   → Evaluation AI (fresh spawn): 5 categories × 10 points
+DISPATCH:        Task Assignment   → TeamCreate + SendMessage to Test AI and Developer AI
+RED:             Test Writing      → Test AI writes tests → Red confirmation
+GREEN:           Implementation    → Developer AI writes minimum code to pass tests
+VERIFY:          Green + Verify    → All tests pass + minimal implementation check
+REFINE:          Refactor          → Developer AI code cleanup, Green re-confirmation
+GATE:QUALITY:    Evaluation        → Evaluation AI (fresh spawn): scored quality assessment
+REVISION:        Revision          → Fix evaluation feedback (if GATE:QUALITY FAIL)
+SHIP:            PR & Review       → Create PR for human review
+LAND:            Merge & Close     → Human approves and merges
 ```
 
 ### Execution Principles
 
-1. **Never skip steps.** Every STEP executes regardless of change size. "This one is simple" is itself a biased judgment.
-2. **STEP 0 is mandatory.** If Git state is not clean, STEP 1 does not begin.
-3. **STEP 1.5 FAIL = issue close.** Existing structure handles the concern — no code change needed.
+1. **Never skip phases.** Every phase executes regardless of change size. "This one is simple" is itself a biased judgment.
+2. **PREFLIGHT is mandatory.** If Git state is not clean, DIAGNOSE does not begin.
+3. **GATE:HYPOTHESIS FAIL = issue close.** Existing structure handles the concern — no code change needed.
 4. **Orchestrator does not implement.** The orchestrator coordinates — teammates do the work.
 5. **Evaluator is always fresh.** Never reuse an evaluation agent — self-reinforcement bias.
 6. **All loops terminate.** Every retry has a maximum count and human escalation point.
@@ -124,41 +124,41 @@ STEP 9: Merge & Close     → Human approves and merges
 
 | Current State | Condition | Next State |
 |---|---|---|
-| STEP 0 | Git clean, branch created | → STEP 1 |
-| STEP 1 | 3 isolated analyses done | → STEP 1.5 |
-| STEP 1.5 PASS | Score >= 7.5 | → STEP 2 |
-| STEP 1.5 FAIL | Existing structure sufficient | → **Issue closed** |
-| STEP 2 | Plan documented | → STEP 3 |
-| STEP 3 PASS | Score >= 7.5, all >= 7 | → STEP 4 |
-| STEP 3 FAIL | Below threshold | → STEP 2 (max 3x) |
-| STEP 4 | Tasks assigned, delegation.md created | → STEP 5a |
-| STEP 5a | Tests written, all Red | → STEP 5b |
-| STEP 5b | Minimum implementation done | → STEP 5c |
-| STEP 5c PASS | All Green + minimal impl check | → STEP 5d |
-| STEP 5c FAIL (test issue) | Test incorrect | → STEP 5a (fix test → re-Red) |
-| STEP 5c FAIL (impl issue) | Implementation incorrect | → STEP 5b (fix impl) |
-| STEP 5c DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
-| STEP 5d | Refactor done, Green maintained | → STEP 6 |
-| STEP 6 PASS | Score >= 7.5, all >= 7 | → STEP 8 |
-| STEP 6 FAIL | Below threshold | → STEP 7 |
-| STEP 6 AUTO-FAIL | Consistency <= 3 | → STEP 4 (major rework) |
-| STEP 7 | Revisions done | → STEP 6 (re-eval, max 3x) |
-| STEP 8 | PR created | → STEP 9 (human) |
-| STEP 9 | Merged | → Done |
+| PREFLIGHT | Git clean, branch created | → DIAGNOSE |
+| DIAGNOSE | 3 isolated analyses done | → GATE:HYPOTHESIS |
+| GATE:HYPOTHESIS PASS | Score >= 7.5 | → ARCHITECT |
+| GATE:HYPOTHESIS FAIL | Existing structure sufficient | → **Issue closed** |
+| ARCHITECT | Plan documented | → GATE:PLAN |
+| GATE:PLAN PASS | Score >= 7.5, all >= 7 | → DISPATCH |
+| GATE:PLAN FAIL | Below threshold | → ARCHITECT (max 3x) |
+| DISPATCH | Tasks assigned, delegation.md created | → RED |
+| RED | Tests written, all Red | → GREEN |
+| GREEN | Minimum implementation done | → VERIFY |
+| VERIFY PASS | All Green + minimal impl check | → REFINE |
+| VERIFY FAIL (test issue) | Test incorrect | → RED (fix test → re-Red) |
+| VERIFY FAIL (impl issue) | Implementation incorrect | → GREEN (fix impl) |
+| VERIFY DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
+| REFINE | Refactor done, Green maintained | → GATE:QUALITY |
+| GATE:QUALITY PASS | Score >= 7.5, all >= 7 | → SHIP |
+| GATE:QUALITY FAIL | Below threshold | → REVISION |
+| GATE:QUALITY AUTO-FAIL | Consistency <= 3 | → DISPATCH (major rework) |
+| REVISION | Revisions done | → GATE:QUALITY (re-eval, max 3x) |
+| SHIP | PR created | → LAND (human) |
+| LAND | Merged | → Done |
 
 ### Regression Rules
 
 | Failure | Max Retries | Escalation |
 |---|---|---|
-| STEP 1.5 FAIL | 0 | Issue closed (by design) |
-| STEP 3 FAIL | 3 → STEP 2 | Human intervention |
-| STEP 5b↔5c cycle | 3 round-trips | Human intervention |
-| STEP 5d FAIL | 2 | Skip refactor, keep Green state |
-| STEP 6 FAIL | 3 → STEP 7 | Human intervention |
+| GATE:HYPOTHESIS FAIL | 0 | Issue closed (by design) |
+| GATE:PLAN FAIL | 3 → ARCHITECT | Human intervention |
+| GREEN↔VERIFY cycle | 3 round-trips | Human intervention |
+| REFINE FAIL | 2 | Skip refactor, keep Green state |
+| GATE:QUALITY FAIL | 3 → REVISION | Human intervention |
 
 ---
 
-## STEP 0: Pre-Work
+## PREFLIGHT: Pre-Work
 
 **[MUST]** Git Clean Check before any work begins.
 
@@ -169,11 +169,11 @@ STEP 9: Merge & Close     → Human approves and merges
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```
 
-If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to STEP 1.
+If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to DIAGNOSE.
 
 ---
 
-## STEP 1: 3-Phase Independent Analysis
+## DIAGNOSE: 3-Phase Independent Analysis
 
 > **Why information isolation?** See [docs/design-rationale.md](docs/design-rationale.md#decision-1-ai-a-does-not-receive-the-issue-content-3-phase-independent-analysis)
 
@@ -225,12 +225,12 @@ Spawn AI-A again with Phase A results + AI-B's resolution approaches.
 | Consistency Impact | Does the inconsistency affect users or AI behavior? (high = significant impact) |
 | Propagation Scope | Is the propagation scope appropriate — not too broad, not missing targets? (high = appropriate scope) |
 
-- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to STEP 1.5
+- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to GATE:HYPOTHESIS
 - **FAIL**: Existing structure handles it → close issue with rationale
 
 ---
 
-## STEP 2: Plan Synthesis
+## ARCHITECT: Plan Synthesis
 
 Merge Phase A, B, and 3 into an implementation plan.
 
@@ -242,11 +242,11 @@ Merge Phase A, B, and 3 into an implementation plan.
 
 ---
 
-## STEP 3: Plan Evaluation
+## GATE:PLAN: Plan Evaluation
 
 **Evaluator**: Fresh-spawned Evaluation AI.
 
-**Input**: Implementation plan from STEP 2.
+**Input**: Implementation plan from ARCHITECT.
 
 **5 categories × 10 points**:
 
@@ -258,16 +258,16 @@ Merge Phase A, B, and 3 into an implementation plan.
 | Consistency | Does this align with design-rationale.md principles? |
 | Test Plan | Are acceptance criteria testable? |
 
-**PASS**: avg >= 7.5, all >= 7 → STEP 4.
-**FAIL**: → STEP 2 (max 3x).
+**PASS**: avg >= 7.5, all >= 7 → DISPATCH.
+**FAIL**: → ARCHITECT (max 3x).
 
 ---
 
-## STEP 4: Task Assignment
+## DISPATCH: Task Assignment
 
 The orchestrator creates a team and spawns teammates to execute the plan.
 
-**[MUST]** The orchestrator must create delegation.md as a mandatory artifact before STEP 5a begins.
+**[MUST]** The orchestrator must create delegation.md as a mandatory artifact before RED begins.
 
 ```
 4-1. TeamCreate — create a team for this issue
@@ -276,7 +276,7 @@ The orchestrator creates a team and spawns teammates to execute the plan.
      - Instruction: "Write tests for these acceptance criteria. Do NOT implement."
 4-3. Spawn Developer AI teammate (Agent with team_name, name="dev-ai")
      - SendMessage: implementation plan + acceptance criteria
-     - Instruction: "Wait for Test AI to complete tests (STEP 5a). Then implement minimum code to pass."
+     - Instruction: "Wait for Test AI to complete tests (RED). Then implement minimum code to pass."
 4-4. Both teammates receive: plan.md, acceptance criteria, affected files list
 4-5. Create delegation.md in .autoflow-state/<issue>/ with the following sections:
 ```
@@ -294,13 +294,13 @@ The orchestrator creates a team and spawns teammates to execute the plan.
 <implementation plan + acceptance criteria for Developer AI>
 ```
 
-**[MUST]** STEP 4 produces delegation.md — it is a mandatory artifact for STEP 5a entry.
-**[MUST]** Test AI starts first (STEP 5a). Developer AI waits until tests are written and Red-confirmed.
+**[MUST]** DISPATCH produces delegation.md — it is a mandatory artifact for RED entry.
+**[MUST]** Test AI starts first (RED). Developer AI waits until tests are written and Red-confirmed.
 **[MUST]** The orchestrator does not write code — it sends instructions and monitors progress.
 
 ---
 
-## STEP 5a-5d: Test-Driven Development Cycle
+## TDD Cycle (RED → GREEN → VERIFY → REFINE)
 
 ### What Is Testable in This Project
 
@@ -311,11 +311,11 @@ The orchestrator creates a team and spawns teammates to execute the plan.
 | Placeholder completeness | Yes | `grep -r '{{' .` after init.sh run — must return empty |
 | Template syntax | Yes | Validate generated CLAUDE.md has no broken markdown |
 | Documentation content | Partial | Verify internal links resolve, code blocks are valid |
-| Pure prose changes | No | Skip TDD cycle, proceed directly to STEP 6 evaluation |
+| Pure prose changes | No | Skip TDD cycle, proceed directly to GATE:QUALITY evaluation |
 
-### STEP 5a: Test Writing (Test AI)
+### RED: Test Writing (Test AI)
 
-**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before STEP 5a begins.
+**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before RED begins.
 
 Test AI teammate writes tests from acceptance criteria.
 
@@ -327,20 +327,20 @@ Test AI teammate writes tests from acceptance criteria.
 5a-4. Report to orchestrator: "Tests written, Red confirmed"
 ```
 
-### STEP 5b: Implementation (Developer AI)
+### GREEN: Implementation (Developer AI)
 
-Developer AI teammate writes minimum code to pass tests. This is the **only** step where implementation code is written.
+Developer AI teammate writes minimum code to pass tests. This is the **only** phase where implementation code is written.
 
 ```
-5b-1. Read the tests from 5a
+5b-1. Read the tests from RED
 5b-2. Write minimum code/content to pass tests
       - [MUST] Do not implement behavior not covered by tests
-      - [MUST] Do not write code before 5a tests exist — that defeats Test First
+      - [MUST] Do not write code before RED tests exist — that defeats Test First
 5b-3. Commit (feat/fix branch)
 5b-4. Report to orchestrator: "Implementation complete"
 ```
 
-### STEP 5c: Green Verification
+### VERIFY: Green Verification
 
 ```
 5c-1. Run all tests
@@ -349,8 +349,8 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** st
   All PASS → 5c-3
 
   Some FAIL → Failure cause analysis:
-    ├─ Test issue → fix test → re-Red → STEP 5b re-entry
-    ├─ Implementation issue → fix implementation → STEP 5c retry
+    ├─ Test issue → fix test → re-Red → GREEN re-entry
+    ├─ Implementation issue → fix implementation → VERIFY retry
     ├─ Both need fixes → fix test first → Red → fix impl → Green
     └─ Deadlock (both claim "no problem") → fresh Evaluation AI arbitrates
 
@@ -361,9 +361,9 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** st
     └─ Config/infra changes → exception allowed (document reason)
 ```
 
-**Max round-trips**: STEP 5b↔5c max 3 cycles → human escalation.
+**Max round-trips**: GREEN↔VERIFY max 3 cycles → human escalation.
 
-### STEP 5d: Refactor
+### REFINE: Refactor
 
 ```
 5d-1. Developer AI teammate runs /simplify
@@ -378,13 +378,13 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** st
 
 **Why /simplify instead of manual judgment?** Previously, the Developer AI decided "refactoring needed?" — but this judgment was routinely skipped with "no cleanup needed." `/simplify` removes this bias by mechanically analyzing the code. The AI no longer decides IF to refactor; a dedicated tool decides WHAT to refactor.
 
-**[MUST]** 5d-2 is mandatory. "No changes were made so tests will pass" is not a valid reason to skip. The re-run confirms that no accidental state changes occurred between STEP 5c and 5d.
+**[MUST]** 5d-2 is mandatory. "No changes were made so tests will pass" is not a valid reason to skip. The re-run confirms that no accidental state changes occurred between VERIFY and REFINE.
 
 ### Pure Documentation Changes
 
 When the change is purely prose (no scripts, no templates with placeholders):
-- Skip STEP 4, 5a-5d entirely
-- Orchestrator delegates the writing to a teammate, then proceed to STEP 6
+- Skip DISPATCH and the TDD cycle (RED–REFINE) entirely
+- Orchestrator delegates the writing to a teammate, then proceed to GATE:QUALITY
 - Document the skip reason: "Pure prose change — no testable behavior"
 
 ---
@@ -407,7 +407,7 @@ When the change is purely prose (no scripts, no templates with placeholders):
 - **[MUST]** Every individual category >= 7
 - **[MUST]** Consistency (design principles) <= 3 → automatic FAIL
 
-### STEP 6 Evaluation Categories
+### GATE:QUALITY Evaluation Categories
 
 | Category | Weight | Description |
 |---|---|---|
@@ -425,7 +425,7 @@ When the change is purely prose (no scripts, no templates with placeholders):
 
 ```json
 {
-  "step": 6,
+  "phase": "GATE:QUALITY",
   "issue": "#N",
   "evaluator": "evaluation-ai",
   "scores": {
@@ -469,7 +469,7 @@ When ambiguity or disagreement arises:
 
 ## Hook Gate
 
-The `check-autoflow-gate.sh` hook enforces STEP progression:
+The `check-autoflow-gate.sh` hook enforces phase progression:
 
 - **Trigger**: Before commit or PR creation
 - **Checks**: Calculates scores from raw `scores` in evaluation JSON
@@ -480,10 +480,10 @@ The `check-autoflow-gate.sh` hook enforces STEP progression:
 
 | Action | Requires |
 |---|---|
-| Commit (STEP 6+) | Evaluation PASS |
+| Commit (GATE:QUALITY+) | Evaluation PASS |
 | PR creation | Evaluation PASS |
-| STEP 0-5 commits | No gate restriction |
-| STEP 7 commits | Allowed (revision in progress) |
+| PREFLIGHT–REFINE commits | No gate restriction |
+| REVISION commits | Allowed (revision in progress) |
 
 ---
 
@@ -517,7 +517,7 @@ Types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`
 - **`git status` before every commit.**
 - **PR closes issue**: PR body includes `Closes #N`.
 
-### Git Clean Check (STEP 0 and STEP 9)
+### Git Clean Check (PREFLIGHT and LAND)
 
 ```bash
 # 1. No uncommitted changes
@@ -542,20 +542,20 @@ State files in `.autoflow-state/` track progress per issue.
 .autoflow-state/
 ├── current-issue          # Contains: issue number
 └── <issue-number>/
-    ├── step               # Current STEP number
-    ├── requirements.md    # STEP 0-1 output
+    ├── phase              # Current phase name
+    ├── requirements.md    # PREFLIGHT–DIAGNOSE output
     ├── analysis/
     │   ├── phase-a.md     # Structure analysis
     │   ├── phase-b.md     # Issue analysis
     │   └── phase-3.md     # Cross-verification
-    ├── plan.md            # STEP 2 output
-    ├── delegation.md      # STEP 4 output (task assignments)
-    ├── evaluation.json    # STEP 6 output
-    └── history.log        # STEP transition log
+    ├── plan.md            # ARCHITECT output
+    ├── delegation.md      # DISPATCH output (task assignments)
+    ├── evaluation.json    # GATE:QUALITY output
+    └── history.log        # Phase transition log
 ```
 
-**Creation**: STEP 0 completion.
-**Completion**: STEP 9 → clean up or archive.
+**Creation**: PREFLIGHT completion.
+**Completion**: LAND → clean up or archive.
 **`.gitignore`**: `.autoflow-state/` must be gitignored.
 
 ---
@@ -569,7 +569,7 @@ Changes to any of these files require checking if related documents need updatin
 | `CLAUDE.md` | This file — process rules change |
 | `CLAUDE.md.template` | Template for users — process/placeholder changes |
 | `docs/design-rationale.md` | New design decisions or principle changes |
-| `docs/autoflow-guide.md` | STEP definitions change |
+| `docs/autoflow-guide.md` | Phase definitions change |
 | `docs/evaluation-system.md` | Scoring categories or thresholds change |
 | `README.md` | Features, structure, or usage changes |
 | `setup/SETUP-GUIDE.md` | Setup procedure changes |
@@ -588,7 +588,7 @@ When `CLAUDE.md.template` changes, verify that `docs/autoflow-guide.md` and `doc
 
 1. Explicit justification for why the existing rationale is wrong or incomplete
 2. Evidence from actual usage (not theoretical improvement)
-3. STEP 6 evaluation with Consistency score >= 8
+3. GATE:QUALITY evaluation with Consistency score >= 8
 
 ### Template Changes Require User Perspective
 

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -11,7 +11,7 @@ It explains _why_ every rule exists. Understanding the design intent takes prior
 ## Table of Contents
 
 1. [Project Overview](#project-overview)
-2. [Auto-Flow Lifecycle (STEP 0–9)](#auto-flow-lifecycle-step-09)
+2. [Auto-Flow Lifecycle](#auto-flow-lifecycle)
 3. [Flow Control Table](#flow-control-table)
 4. [Agent Roles](#agent-roles)
 5. [3-Phase Independent Analysis](#3-phase-independent-analysis)
@@ -46,38 +46,38 @@ It explains _why_ every rule exists. Understanding the design intent takes prior
 
 ---
 
-## Auto-Flow Lifecycle (STEP 0–9)
+## Auto-Flow Lifecycle (PREFLIGHT → LAND)
 
-Auto-Flow is a structured development lifecycle that ensures quality through evaluation gates at every stage. Each STEP has clear entry/exit criteria.
+Auto-Flow is a structured development lifecycle that ensures quality through evaluation gates at every stage. Each phase has clear entry/exit criteria.
 
-| STEP | Name | Description | Exit Criteria |
-|------|------|-------------|---------------|
-| 0 | **Pre-Work** | Git clean check, upstream sync, branch creation | Git clean, branch created |
-| 1 | **3-Phase Analysis** | Understand the issue + information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
-| 1.5 | **Issue Analysis Eval** | Gate: is the analysis sufficient? | Score >= 7.5 or issue closed |
-| 2 | **Plan Synthesis** | Merge analyses into implementation plan | Plan approved |
-| 3 | **Plan Evaluation** | Fresh Evaluation AI scores the plan | Score >= 7.5, all >= 7 |
-| 4 | **Task Assignment** | Delegate to Test AI and Developer AI | Tasks assigned to teammates |
-| 5a | **Test Writing** | Test AI writes tests from acceptance criteria | Tests written, all Red |
-| 5b | **Implementation** | Developer AI writes minimum code to pass tests | Minimum implementation done |
-| 5c | **Green Verification** | All tests pass + minimal implementation check | All Green |
-| 5d | **Refactor** | Code cleanup, Green re-confirmation | Refactor done, Green maintained |
-| 6 | **Evaluation** | Fresh-spawned Evaluation AI scores the work | Score >= 7.5 (PASS) |
-| 7 | **Revision** | Fix issues from evaluation (if needed) | Re-evaluation PASS |
-| 8 | **PR & Review** | Create PR for human review | PR submitted |
-| 9 | **Merge & Close** | Merge after human approval | Issue closed |
+| Phase | Name | Description | Exit Criteria |
+|-------|------|-------------|---------------|
+| PREFLIGHT | **Pre-Work** | Git clean check, upstream sync, branch creation | Git clean, branch created |
+| DIAGNOSE | **3-Phase Analysis** | Understand the issue + information-isolated structure analysis (bias prevention) | 3 isolated analyses completed |
+| GATE:HYPOTHESIS | **Issue Analysis Eval** | Gate: is the analysis sufficient? | Score >= 7.5 or issue closed |
+| ARCHITECT | **Plan Synthesis** | Merge analyses into implementation plan | Plan approved |
+| GATE:PLAN | **Plan Evaluation** | Fresh Evaluation AI scores the plan | Score >= 7.5, all >= 7 |
+| DISPATCH | **Task Assignment** | Delegate to Test AI and Developer AI | Tasks assigned to teammates |
+| RED | **Test Writing** | Test AI writes tests from acceptance criteria | Tests written, all Red |
+| GREEN | **Implementation** | Developer AI writes minimum code to pass tests | Minimum implementation done |
+| VERIFY | **Green Verification** | All tests pass + minimal implementation check | All Green |
+| REFINE | **Refactor** | Code cleanup, Green re-confirmation | Refactor done, Green maintained |
+| GATE:QUALITY | **Evaluation** | Fresh-spawned Evaluation AI scores the work | Score >= 7.5 (PASS) |
+| REVISION | **Revision** | Fix issues from evaluation (if needed) | Re-evaluation PASS |
+| SHIP | **PR & Review** | Create PR for human review | PR submitted |
+| LAND | **Merge & Close** | Merge after human approval | Issue closed |
 
 ### Execution Principles
 
-1. **Never skip steps.** Each STEP builds on the previous one — regardless of change size. "This one is simple" is itself a biased judgment.
-2. **STEP 0 is mandatory.** If Git state is not clean, STEP 1 does not begin.
-3. **Regression is allowed.** If STEP 6 fails, return to STEP 7 (or STEP 3 for major issues).
-4. **STEP 1.5 FAIL = issue close.** If existing structure handles the concern, no code change is needed.
-5. **Human gates exist.** STEP 8→9 always requires human approval.
-6. **State is tracked.** Use `.autoflow-state/` files to persist STEP status.
+1. **Never skip phases.** Each phase builds on the previous one — regardless of change size. "This one is simple" is itself a biased judgment.
+2. **PREFLIGHT is mandatory.** If Git state is not clean, DIAGNOSE does not begin.
+3. **Regression is allowed.** If GATE:QUALITY fails, return to REVISION (or GATE:PLAN for major issues).
+4. **GATE:HYPOTHESIS FAIL = issue close.** If existing structure handles the concern, no code change is needed.
+5. **Human gates exist.** SHIP→LAND always requires human approval.
+6. **State is tracked.** Use `.autoflow-state/` files to persist phase status.
 7. **Pipeline is stateless.** Past issue evaluations do not influence current analysis. Improvement happens outside the pipeline, through human-driven CLAUDE.md updates.
 
-### STEP 0: Pre-Work
+### PREFLIGHT: Pre-Work
 
 **[MUST]** Git Clean Check before any work begins.
 
@@ -88,7 +88,7 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```
 
-If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to STEP 1.
+If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to DIAGNOSE.
 
 ---
 
@@ -96,27 +96,27 @@ If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to 
 
 | Current State | Condition | Next State |
 |--------------|-----------|------------|
-| STEP 0 | Git clean, branch created | → STEP 1 |
-| STEP 1 | 3 isolated analyses done | → STEP 1.5 |
-| STEP 1.5 (score >= 7.5) | PASS | → STEP 2 |
-| STEP 1.5 (FAIL) | Existing structure sufficient | → **Issue closed** |
-| STEP 2 | Plan approved | → STEP 3 |
-| STEP 3 PASS | Score >= 7.5, all >= 7 | → STEP 4 |
-| STEP 3 FAIL | Below threshold | → STEP 2 (max 3x) |
-| STEP 4 | Tasks assigned, delegation.md created | → STEP 5a |
-| STEP 5a | Tests written, all Red | → STEP 5b |
-| STEP 5b | Minimum implementation done | → STEP 5c |
-| STEP 5c PASS | All Green + minimal impl check | → STEP 5d |
-| STEP 5c FAIL (test issue) | Test incorrect | → STEP 5a (fix test → re-Red) |
-| STEP 5c FAIL (impl issue) | Implementation incorrect | → STEP 5b (fix impl) |
-| STEP 5c DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
-| STEP 5d | Refactor done, Green maintained | → STEP 6 |
-| STEP 6 (score >= 7.5, all categories >= 7) | PASS | → STEP 8 |
-| STEP 6 (score < 7.5 or category < 7) | FAIL | → STEP 7 |
-| STEP 6 (security <= 3) | AUTO-FAIL | → STEP 4 (major rework) |
-| STEP 7 | Re-eval PASS | → STEP 8 |
-| STEP 8 | PR submitted | → STEP 9 (human) |
-| STEP 9 | Merged | → Done |
+| PREFLIGHT | Git clean, branch created | → DIAGNOSE |
+| DIAGNOSE | 3 isolated analyses done | → GATE:HYPOTHESIS |
+| GATE:HYPOTHESIS (score >= 7.5) | PASS | → ARCHITECT |
+| GATE:HYPOTHESIS (FAIL) | Existing structure sufficient | → **Issue closed** |
+| ARCHITECT | Plan approved | → GATE:PLAN |
+| GATE:PLAN PASS | Score >= 7.5, all >= 7 | → DISPATCH |
+| GATE:PLAN FAIL | Below threshold | → ARCHITECT (max 3x) |
+| DISPATCH | Tasks assigned, delegation.md created | → RED |
+| RED | Tests written, all Red | → GREEN |
+| GREEN | Minimum implementation done | → VERIFY |
+| VERIFY PASS | All Green + minimal impl check | → REFINE |
+| VERIFY FAIL (test issue) | Test incorrect | → RED (fix test → re-Red) |
+| VERIFY FAIL (impl issue) | Implementation incorrect | → GREEN (fix impl) |
+| VERIFY DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
+| REFINE | Refactor done, Green maintained | → GATE:QUALITY |
+| GATE:QUALITY (score >= 7.5, all categories >= 7) | PASS | → SHIP |
+| GATE:QUALITY (score < 7.5 or category < 7) | FAIL | → REVISION |
+| GATE:QUALITY (security <= 3) | AUTO-FAIL | → DISPATCH (major rework) |
+| REVISION | Re-eval PASS | → SHIP |
+| SHIP | PR submitted | → LAND (human) |
+| LAND | Merged | → Done |
 
 ---
 
@@ -131,17 +131,17 @@ Auto-Flow uses **multi-agent role separation** to prevent single-point-of-failur
 
 ### Developer AI
 - **Scope**: Assigned sub-repo only
-- **Responsibilities**: Implementation (STEP 5b), refactor (STEP 5d)
-- **Cannot**: Evaluate own work (STEP 6)
+- **Responsibilities**: Implementation (GREEN), refactor (REFINE)
+- **Cannot**: Evaluate own work (GATE:QUALITY)
 
 ### Test AI
 - **Scope**: Assigned sub-repo only
-- **Responsibilities**: Write tests from acceptance criteria (STEP 5a), verify Green (STEP 5c)
+- **Responsibilities**: Write tests from acceptance criteria (RED), verify Green (VERIFY)
 - **Cannot**: Modify implementation code
 
 ### Evaluation AI
 - **Scope**: Read-only across relevant repos
-- **Responsibilities**: Score the work using the 10-point scale (STEPs 1.5, 6)
+- **Responsibilities**: Score the work using the 10-point scale (GATE:HYPOTHESIS, GATE:QUALITY)
 - **Cannot**: Fix code — only report issues
 - **Critical**: Must be **spawned fresh** for every evaluation. Never reuse an evaluation agent — self-reinforcement bias makes prior investment in reasoning influence the judgment. See [docs/design-rationale.md](docs/design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
 
@@ -186,7 +186,7 @@ Evaluation AI → Orchestrator: "Score: 8/10 — PASS"
 
 > **Why information isolation?** See [docs/design-rationale.md](docs/design-rationale.md#decision-1-ai-a-does-not-receive-the-issue-content-3-phase-independent-analysis)
 
-To prevent tunnel-vision bias, STEP 1 uses **information isolation** — not just different perspectives, but strictly separated inputs.
+To prevent tunnel-vision bias, DIAGNOSE uses **information isolation** — not just different perspectives, but strictly separated inputs.
 
 ### Phase A: Structure Analysis (AI-A) — DOES NOT SEE THE ISSUE
 - **AI-A receives only the codebase.** It never sees the issue text.
@@ -228,21 +228,21 @@ To prevent tunnel-vision bias, STEP 1 uses **information isolation** — not jus
 | Consistency Impact | Does the inconsistency affect users or AI behavior? (high = significant impact) |
 | Propagation Scope | Is the propagation scope appropriate — not too broad, not missing targets? (high = appropriate scope) |
 
-- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to STEP 1.5
+- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to GATE:HYPOTHESIS
 - **FAIL**: Existing structure handles it → close issue with rationale
 
-### Synthesis (STEP 2)
+### Synthesis (ARCHITECT)
 Merge all three analyses into a single implementation plan. Conflicts between phases must be explicitly resolved with rationale.
 
 **Do NOT give AI-A the issue content "for efficiency."** This destroys the core mechanism. See design rationale.
 
 ---
 
-## STEP 3: Plan Evaluation
+## GATE:PLAN: Plan Evaluation
 
 **Evaluator**: Fresh-spawned Evaluation AI.
 
-**Input**: Implementation plan from STEP 2.
+**Input**: Implementation plan from ARCHITECT.
 
 **5 categories × 10 points**:
 
@@ -254,16 +254,16 @@ Merge all three analyses into a single implementation plan. Conflicts between ph
 | Consistency | Does this align with design-rationale.md principles? |
 | Test Plan | Are acceptance criteria testable? |
 
-**PASS**: avg >= 7.5, all >= 7 → STEP 4.
-**FAIL**: → STEP 2 (max 3x).
+**PASS**: avg >= 7.5, all >= 7 → DISPATCH.
+**FAIL**: → ARCHITECT (max 3x).
 
 ---
 
-## STEP 4: Task Assignment
+## DISPATCH: Task Assignment
 
 The orchestrator creates a team and assigns tasks to teammates.
 
-**[MUST]** The orchestrator must create delegation.md as a mandatory artifact before STEP 5a begins.
+**[MUST]** The orchestrator must create delegation.md as a mandatory artifact before RED begins.
 
 ```
 4-1. Spawn Test AI teammate
@@ -271,7 +271,7 @@ The orchestrator creates a team and assigns tasks to teammates.
      - Instruction: "Write tests for these acceptance criteria. Do NOT implement."
 4-2. Spawn Developer AI teammate
      - SendMessage: implementation plan + acceptance criteria
-     - Instruction: "Wait for Test AI to complete tests (STEP 5a). Then implement minimum code to pass."
+     - Instruction: "Wait for Test AI to complete tests (RED). Then implement minimum code to pass."
 4-3. Both teammates receive: plan, acceptance criteria, affected files list
 4-4. Create delegation.md in .autoflow-state/<issue>/ with the following sections:
 ```
@@ -289,16 +289,16 @@ The orchestrator creates a team and assigns tasks to teammates.
 <implementation plan + acceptance criteria for Developer AI>
 ```
 
-**[MUST]** STEP 4 produces delegation.md — it is a mandatory artifact for STEP 5a entry.
-**[MUST]** Test AI starts first (STEP 5a). Developer AI waits until tests are written and Red-confirmed.
+**[MUST]** DISPATCH produces delegation.md — it is a mandatory artifact for RED entry.
+**[MUST]** Test AI starts first (RED). Developer AI waits until tests are written and Red-confirmed.
 
 ---
 
-## STEP 5a-5d: Test-Driven Development Cycle
+## TDD cycle: Test-Driven Development Cycle
 
-### STEP 5a: Test Writing (Test AI)
+### RED: Test Writing (Test AI)
 
-**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before STEP 5a begins.
+**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before RED begins.
 
 Test AI writes tests from acceptance criteria.
 
@@ -309,9 +309,9 @@ Test AI writes tests from acceptance criteria.
 5a-3. For untestable items → write manual verification checklist
 ```
 
-### STEP 5b: Implementation (Developer AI)
+### GREEN: Implementation (Developer AI)
 
-Developer AI writes minimum code to pass tests. This is the **only** step where implementation code is written.
+Developer AI writes minimum code to pass tests. This is the **only** phase where implementation code is written.
 
 ```
 5b-1. Read the tests from 5a
@@ -320,7 +320,7 @@ Developer AI writes minimum code to pass tests. This is the **only** step where 
 5b-3. Commit (feat/fix branch)
 ```
 
-### STEP 5c: Green Verification
+### VERIFY: Green Verification
 
 ```
 5c-1. Run all tests
@@ -329,8 +329,8 @@ Developer AI writes minimum code to pass tests. This is the **only** step where 
   All PASS → 5c-3
 
   Some FAIL → Failure cause analysis:
-    ├─ Test issue → fix test → re-Red → STEP 5b re-entry
-    ├─ Implementation issue → fix implementation → STEP 5c retry
+    ├─ Test issue → fix test → re-Red → GREEN re-entry
+    ├─ Implementation issue → fix implementation → VERIFY retry
     ├─ Both need fixes → fix test first → Red → fix impl → Green
     └─ Deadlock (both claim "no problem") → fresh Evaluation AI arbitrates
 
@@ -341,9 +341,9 @@ Developer AI writes minimum code to pass tests. This is the **only** step where 
     └─ Config/infra changes → exception allowed (document reason)
 ```
 
-**Max round-trips**: STEP 5b↔5c max 3 cycles → human escalation.
+**Max round-trips**: GREEN↔VERIFY max 3 cycles → human escalation.
 
-### STEP 5d: Refactor
+### REFINE: Refactor
 
 ```
 5d-1. Developer AI runs /simplify
@@ -358,24 +358,24 @@ Developer AI writes minimum code to pass tests. This is the **only** step where 
 
 **Why /simplify instead of manual judgment?** Previously, the Developer AI decided "refactoring needed?" — but this judgment was routinely skipped with "no cleanup needed." `/simplify` removes this bias by mechanically analyzing the code. The AI no longer decides IF to refactor; a dedicated tool decides WHAT to refactor.
 
-**[MUST]** 5d-2 is mandatory. "No changes were made so tests will pass" is not a valid reason to skip. The re-run confirms that no accidental state changes occurred between STEP 5c and 5d.
+**[MUST]** 5d-2 is mandatory. "No changes were made so tests will pass" is not a valid reason to skip. The re-run confirms that no accidental state changes occurred between VERIFY and REFINE.
 
 ### Pure Documentation Changes
 
 When the change is purely prose (no scripts, no templates with placeholders):
-- Skip TDD cycle (STEP 5a-5d) entirely
-- Proceed directly to STEP 6 evaluation
+- Skip TDD cycle (RED through REFINE) entirely
+- Proceed directly to GATE:QUALITY evaluation
 - Document the skip reason: "Pure prose change — no testable behavior"
 
 ### Regression Rules
 
 | Failure | Max Retries | Escalation |
 |---|---|---|
-| STEP 1.5 FAIL | 0 | Issue closed (by design) |
-| STEP 3 FAIL | 3 → STEP 2 | Human intervention |
-| STEP 5b↔5c cycle | 3 round-trips | Human intervention |
-| STEP 5d FAIL | 2 | Skip refactor, keep Green state |
-| STEP 6 FAIL | 3 → STEP 7 | Human intervention |
+| GATE:HYPOTHESIS FAIL | 0 | Issue closed (by design) |
+| GATE:PLAN FAIL | 3 → ARCHITECT | Human intervention |
+| GREEN↔VERIFY cycle | 3 round-trips | Human intervention |
+| REFINE FAIL | 2 | Skip refactor, keep Green state |
+| GATE:QUALITY FAIL | 3 → REVISION | Human intervention |
 
 ---
 
@@ -394,9 +394,9 @@ When the change is purely prose (no scripts, no templates with placeholders):
 | 1–2 | Failing — does not meet requirements |
 
 ### PASS Criteria
-- **Overall weighted score >= 7.5** to proceed to STEP 8
+- **Overall weighted score >= 7.5** to proceed to SHIP
 - **No individual category below 7**
-- **Security score <= 3 → automatic FAIL** (mandatory rework → STEP 4, cannot be diluted by averaging)
+- **Security score <= 3 → automatic FAIL** (mandatory rework → DISPATCH, cannot be diluted by averaging)
 
 ### Evaluation Categories
 
@@ -412,7 +412,7 @@ When the change is purely prose (no scripts, no templates with placeholders):
 
 ```json
 {
-  "step": 6,
+  "phase": "GATE:QUALITY",
   "issue": "#123",
   "evaluator": "evaluation-ai",
   "scores": {
@@ -457,7 +457,7 @@ When ambiguity or disagreement arises:
 
 ## Hook Gate
 
-The Auto-Flow Hook (`check-autoflow-gate.sh`) enforces STEP progression:
+The Auto-Flow Hook (`check-autoflow-gate.sh`) enforces phase progression:
 
 - **Trigger**: Runs before commit or PR creation
 - **Checks**: Calculates scores directly from raw `scores` in evaluation JSON

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The setup wizard will ask for your project configuration and generate all files.
 
 ### Option B: Manual Setup
 
-See [setup/SETUP-GUIDE.md](setup/SETUP-GUIDE.md) for step-by-step manual instructions.
+See [setup/SETUP-GUIDE.md](setup/SETUP-GUIDE.md) for manual setup instructions.
 
 ---
 
@@ -73,7 +73,7 @@ claude-autoflow/
 │       └── check-autoflow-gate.sh     # Auto-Flow gate hook
 │
 ├── docs/
-│   ├── autoflow-guide.md              # Step-by-step Auto-Flow guide
+│   ├── autoflow-guide.md              # Phase-by-phase Auto-Flow guide
 │   ├── git-workflow.md                # Git procedures
 │   ├── repo-boundary-rules.md         # Cross-repo coordination rules
 │   ├── submodule-common-rules.md      # Sub-repo shared rules
@@ -136,7 +136,7 @@ At GATE:QUALITY, an independent Evaluation AI scores the work across 5 categorie
 The `check-autoflow-gate.sh` hook reads `.autoflow-state/` files to prevent:
 - Committing before evaluation passes
 - Creating PRs without meeting the PASS threshold
-- Skipping required steps
+- Skipping required phases
 
 ---
 
@@ -175,7 +175,7 @@ Templates use `{{UPPER_SNAKE_CASE}}` placeholders:
 | Document | Description |
 |----------|-------------|
 | [**Design Rationale**](docs/design-rationale.md) | **Read first** — why every design decision was made |
-| [Auto-Flow Guide](docs/autoflow-guide.md) | Detailed step-by-step lifecycle |
+| [Auto-Flow Guide](docs/autoflow-guide.md) | Detailed phase-by-phase lifecycle |
 | [Evaluation System](docs/evaluation-system.md) | Scoring, PASS criteria, output format |
 | [Git Workflow](docs/git-workflow.md) | Branch naming, commits, PR process |
 | [Repo Boundary Rules](docs/repo-boundary-rules.md) | Cross-repo coordination rules |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A reusable template for structured, evaluation-gated AI-assisted software development with [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
-Auto-Flow is a **10-step development lifecycle** that ensures quality through multi-agent role separation, independent analysis, and quantified evaluation gates. This template lets you adopt the methodology in any project.
+Auto-Flow is a **14-phase development lifecycle** that ensures quality through multi-agent role separation, independent analysis, and quantified evaluation gates. This template lets you adopt the methodology in any project.
 
 ---
 
@@ -11,19 +11,20 @@ Auto-Flow is a **10-step development lifecycle** that ensures quality through mu
 Auto-Flow structures every code change through a defined lifecycle:
 
 ```
-STEP 0  Pre-Work                — Git clean check, branch creation
-STEP 1  3-Phase Analysis        — Independent bias-free analysis
-STEP 2  Plan Synthesis          — Merge analyses into a plan
-STEP 3  Plan Evaluation          — Scored plan assessment (gate)
-STEP 4  Task Assignment          — Delegate to Test AI and Developer AI
-STEP 5a Test Writing             — Tests from acceptance criteria (Red)
-STEP 5b Implementation           — Minimum code to pass tests
-STEP 5c Green Verification       — All tests pass + minimal check
-STEP 5d Refactor                 — Code cleanup, Green re-confirmation
-STEP 6  Evaluation              — Scored quality assessment (gate)
-STEP 7  Revision (if needed)    — Fix evaluation feedback
-STEP 8  PR & Review             — Submit for human review
-STEP 9  Merge & Close           — Human approves and merges
+PREFLIGHT    Pre-Work                — Git clean check, branch creation
+DIAGNOSE     3-Phase Analysis        — Independent bias-free analysis
+GATE:HYPOTHESIS  Hypothesis Gate     — Scored hypothesis assessment (gate, bug issues only)
+ARCHITECT    Plan Synthesis          — Merge analyses into a plan
+GATE:PLAN    Plan Evaluation         — Scored plan assessment (gate)
+DISPATCH     Task Assignment         — Delegate to Test AI and Developer AI
+RED          Test Writing            — Tests from acceptance criteria (Red)
+GREEN        Implementation          — Minimum code to pass tests
+VERIFY       Green Verification      — All tests pass + minimal check
+REFINE       Refactor                — Code cleanup, Green re-confirmation
+GATE:QUALITY Evaluation             — Scored quality assessment (gate)
+REVISION     Revision (if needed)   — Fix evaluation feedback
+SHIP         PR & Review             — Submit for human review
+LAND         Merge & Close           — Human approves and merges
 ```
 
 ### Key Features
@@ -118,7 +119,7 @@ Different AI agents handle different responsibilities:
 
 ### 3. Evaluation Gate
 
-At STEP 6, an independent Evaluation AI scores the work across 5 categories:
+At GATE:QUALITY, an independent Evaluation AI scores the work across 5 categories:
 
 | Category | Weight |
 |----------|--------|

--- a/claude-autoflow-template-workplan.md
+++ b/claude-autoflow-template-workplan.md
@@ -8,7 +8,7 @@
 
 ### 이식 대상
 `Munsik-Park/ontology-platform`의 CLAUDE.md, Hook, docs에 녹아 있는 Claude Code 운영 노하우:
-- Auto-Flow (STEP 0~9) 개발 생명주기
+- Auto-Flow (PREFLIGHT~LAND) 개발 생명주기
 - 3-Phase 독립 구조 분석 (편향 방지)
 - Multi-agent 역할 분리 (오케스트레이터 / 개발 AI / 테스트 AI / 평가 AI)
 - Hook 기반 평가 게이트 (`check-autoflow-gate.sh`)
@@ -164,7 +164,7 @@ Placeholder 형식: `{{UPPER_SNAKE_CASE}}`
 
 #### 3-2. `docs/autoflow-guide.md` 작성
 현재 CLAUDE.md에 내장된 Auto-Flow 설명을 독립 문서로 분리:
-- 각 STEP의 목적과 완료 조건
+- 각 phase의 목적과 완료 조건
 - Flow Control 표
 - 회귀 규칙
 - 실행 원칙
@@ -217,7 +217,7 @@ Phase 1부터 시작해주세요.
 
 ## 핵심 설계 원칙 (작업 중 유지)
 
-1. **Auto-Flow 로직은 건드리지 않는다** — STEP 정의, 평가 기준, Hook 로직은 범용 그대로 유지
+1. **Auto-Flow 로직은 건드리지 않는다** — phase 정의, 평가 기준, Hook 로직은 범용 그대로 유지
 2. **placeholder는 최소화한다** — 필수적인 것만. 너무 많으면 이식 비용이 높아짐
 3. **선택적 섹션은 주석으로** — 서브모듈 불필요한 경우를 위한 "여기서 여기까지 제거" 가이드
 4. **서브 레포 CLAUDE.md는 얇게** — 오케스트레이터 CLAUDE.md를 복사하지 않고 참조하도록

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -1,4 +1,4 @@
-# Auto-Flow Guide — Step-by-Step Development Lifecycle
+# Auto-Flow Guide — Phase-by-Phase Development Lifecycle
 
 > Auto-Flow is a structured, evaluation-gated development lifecycle for AI-assisted software engineering with Claude Code.
 
@@ -6,17 +6,17 @@
 
 ## Overview
 
-Auto-Flow defines **10 STEPs (0–9)** that guide every code change from issue analysis to merge. Each STEP has explicit entry/exit criteria, and an evaluation gate prevents low-quality work from reaching production.
+Auto-Flow defines **14 phases (PREFLIGHT → LAND)** that guide every code change from issue analysis to merge. Each phase has explicit entry/exit criteria, and an evaluation gate prevents low-quality work from reaching production.
 
 The key principles:
-- **No shortcuts** — every STEP is executed in order
+- **No shortcuts** — every phase is executed in order
 - **Multi-agent separation** — different roles handle implementation, testing, and evaluation
 - **Bias prevention** — 3-phase independent analysis before coding
 - **Quantified quality** — 10-point evaluation with defined PASS threshold
 
 ---
 
-## STEP 0: Pre-Work
+## PREFLIGHT: Pre-Work
 
 **Goal**: Ensure a clean Git state before any analysis or coding begins.
 
@@ -29,14 +29,14 @@ The key principles:
 ### Exit Criteria
 - Git working tree is clean
 - Branch created from latest main
-- Ready for STEP 1 analysis
+- Ready for DIAGNOSE analysis
 
 ### Hard Stop Rule
-If Git state is not clean after resolution attempts, **stop and report to user**. Do NOT proceed to STEP 1. Starting work on a dirty Git state causes merge conflicts, lost changes, and broken state downstream.
+If Git state is not clean after resolution attempts, **stop and report to user**. Do NOT proceed to DIAGNOSE. Starting work on a dirty Git state causes merge conflicts, lost changes, and broken state downstream.
 
 ---
 
-## STEP 1: 3-Phase Independent Analysis (Information Isolation)
+## DIAGNOSE: 3-Phase Independent Analysis (Information Isolation)
 
 **Goal**: Prevent tunnel-vision bias through **information isolation** — not just different perspectives, but strictly separated inputs.
 
@@ -96,7 +96,7 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 | Consistency Impact | Does the inconsistency affect users or AI behavior? (high = significant impact) |
 | Propagation Scope | Is the propagation scope appropriate — not too broad, not missing targets? (high = appropriate scope) |
 
-- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to STEP 1.5
+- **PASS** (avg >= 7.5, all >= 7): Change needed → proceed to GATE:HYPOTHESIS
 - **FAIL**: Existing structure handles it → close issue with rationale
 
 ### Exit Criteria
@@ -107,7 +107,7 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 
 ---
 
-## STEP 1.5: Issue Analysis Evaluation (Gate)
+## GATE:HYPOTHESIS: Issue Analysis Evaluation (Gate)
 
 **Goal**: Ensure only well-analyzed issues proceed to implementation. This gate is strict because insufficient analysis at this stage causes larger costs downstream.
 
@@ -119,17 +119,17 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 3. Produces a scored evaluation
 
 ### PASS / FAIL
-- **PASS** (score >= 7.5): Proceed to STEP 2
+- **PASS** (score >= 7.5): Proceed to ARCHITECT
 - **FAIL**: **Close the issue.** If the structure already handles the concern, no code change is needed. This is not a regression — it is the system working correctly. The best code is code that is never written.
 
 ### Exit Criteria
 - Evaluation report saved
-- PASS → proceed to STEP 2
+- PASS → proceed to ARCHITECT
 - FAIL → issue closed (existing structure sufficient)
 
 ---
 
-## STEP 2: Plan Synthesis
+## ARCHITECT: Plan Synthesis
 
 **Goal**: Merge the three analyses into a single, coherent implementation plan.
 
@@ -167,25 +167,25 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 
 ---
 
-## STEP 3: Plan Evaluation
+## GATE:PLAN: Plan Evaluation
 
 **Goal**: An independent Evaluation AI scores the implementation plan before coding begins.
 
 > **The Evaluation AI is spawned fresh** for this step — it carries no prior conversation history.
 
 ### Process
-1. A freshly spawned Evaluation AI receives the implementation plan from STEP 2
+1. A freshly spawned Evaluation AI receives the implementation plan from ARCHITECT
 2. Scores across 5 categories (Feasibility, Dependencies, Scope, Consistency, Test Plan)
 3. Produces a scored evaluation
 
 ### PASS / FAIL
-- **PASS** (score >= 7.5, all categories >= 7): Proceed to STEP 4
-- **FAIL**: Return to STEP 2 (max 3 revision cycles)
+- **PASS** (score >= 7.5, all categories >= 7): Proceed to DISPATCH
+- **FAIL**: Return to ARCHITECT (max 3 revision cycles)
 
 ### Exit Criteria
 - Evaluation report saved
-- PASS → proceed to STEP 4
-- FAIL → return to STEP 2 for plan revision
+- PASS → proceed to DISPATCH
+- FAIL → return to ARCHITECT for plan revision
 
 ---
 
@@ -208,7 +208,7 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 
 ---
 
-## STEP 4: Task Assignment
+## DISPATCH: Task Assignment
 
 **Goal**: The orchestrator delegates implementation work to Test AI and Developer AI teammates.
 
@@ -216,7 +216,7 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 - Spawn Test AI teammate with acceptance criteria
 - Spawn Developer AI teammate with implementation plan
 - **[MUST]** Create delegation.md as a mandatory artifact in `.autoflow-state/<issue>/`
-- Test AI starts first (STEP 5a) — Developer AI waits
+- Test AI starts first (RED) — Developer AI waits
 
 ### delegation.md Format
 
@@ -238,11 +238,11 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 
 ---
 
-## STEP 5a: Test Writing (Test AI)
+## RED: Test Writing (Test AI)
 
 **Goal**: Test AI writes tests from acceptance criteria. Tests must all FAIL (Red confirmation).
 
-**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before STEP 5a begins.
+**Entry precondition**: delegation.md must exist in `.autoflow-state/<issue>/` before RED begins.
 
 ### Activities
 - Convert acceptance criteria into test scripts
@@ -253,35 +253,35 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 ### Exit Criteria
 - All tests written
 - All tests FAIL (Red confirmed)
-- Ready for Developer AI implementation
+- Ready for Developer AI implementation (GREEN)
 
 ---
 
-## STEP 5b: Implementation (Developer AI)
+## GREEN: Implementation (Developer AI)
 
 **Goal**: Developer AI writes minimum code to pass tests.
 
 ### Activities
-- Read the tests from STEP 5a
+- Read the tests from RED
 - Write minimum code/content to pass tests
 - Do not implement behavior not covered by tests
 - Commit changes
 
 ### Exit Criteria
 - Minimum implementation complete
-- Ready for Green verification
+- Ready for VERIFY
 
 ---
 
-## STEP 5c: Green Verification
+## VERIFY: Green Verification
 
 **Goal**: All tests pass and implementation is minimal.
 
 ### Activities
 - Run all tests
 - If some fail, analyze failure cause:
-  - **Test issue**: Fix test → re-Red → STEP 5b re-entry
-  - **Implementation issue**: Fix implementation → STEP 5c retry
+  - **Test issue**: Fix test → re-Red → GREEN re-entry
+  - **Implementation issue**: Fix implementation → VERIFY retry
   - **Both need fixes**: Fix test first → Red → fix impl → Green
   - **Deadlock** (both claim "no problem"): Fresh Evaluation AI arbitrates
 - Minimal implementation check: verify no code exists that isn't covered by tests
@@ -289,11 +289,11 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 ### Exit Criteria
 - All tests pass (Green)
 - No uncovered implementation code
-- Max round-trips: STEP 5b↔5c max 3 cycles → human escalation
+- Max round-trips: GREEN↔VERIFY max 3 cycles → human escalation
 
 ---
 
-## STEP 5d: Refactor
+## REFINE: Refactor
 
 **Goal**: Code cleanup without changing behavior. Tests must pass without modification.
 
@@ -302,9 +302,9 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 - Applies suggested fixes (no behavior change — tests must pass without modification)
 - If `/simplify` finds nothing → proceed to re-run (DO NOT SKIP)
 - **[MUST]** Re-run ALL tests → Green maintained
-  - This step is NEVER skipped, even when `/simplify` made no changes
+  - This phase is NEVER skipped, even when `/simplify` made no changes
   - "No changes were made so tests will pass" is not a valid reason to skip
-  - The re-run confirms that no accidental state changes occurred between STEP 5c and 5d
+  - The re-run confirms that no accidental state changes occurred between VERIFY and REFINE
 - If simplify breaks tests → revert changes, fix (max 2 attempts, then keep pre-refactor state)
 - Commit (refactor type, or skip commit if no changes)
 
@@ -319,7 +319,7 @@ The orchestrator coordinates only — it does **not** implement. File-level boun
 
 ## Evaluation AI Prompt Rules
 
-When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's prompt must follow these rules:
+When spawning the Evaluation AI (at GATE:HYPOTHESIS, GATE:PLAN, and GATE:QUALITY), the orchestrator's prompt must follow these rules:
 
 1. **[MUST]** Include: evaluation type, `CLAUDE.md > [section]` reference, target file paths
 2. **[MUST]** Do NOT copy evaluation criteria into the prompt — instruct the AI to read CLAUDE.md directly
@@ -328,7 +328,7 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 ---
 
-## STEP 6: Evaluation
+## GATE:QUALITY: Evaluation
 
 **Goal**: An independent Evaluation AI scores the work objectively.
 
@@ -350,9 +350,9 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 | Documentation | 15% | Docs updated, links valid, examples accurate? |
 
 ### PASS / FAIL
-- **PASS**: Overall weighted score >= 7.5 AND no individual category below 7 → proceed to STEP 8
-- **FAIL**: Overall score < 7.5 OR any category below 7 → return to STEP 7 (or STEP 3 for major issues)
-- **AUTO-FAIL**: Consistency score <= 3 → STEP 4 (mandatory rework regardless of other scores)
+- **PASS**: Overall weighted score >= 7.5 AND no individual category below 7 → proceed to SHIP
+- **FAIL**: Overall score < 7.5 OR any category below 7 → return to REVISION (or GATE:PLAN for major issues)
+- **AUTO-FAIL**: Consistency score <= 3 → DISPATCH (mandatory rework regardless of other scores)
 
 ### Exit Criteria
 - Evaluation report saved to `.autoflow-state/<issue>/evaluation.json`
@@ -360,15 +360,15 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 ---
 
-## STEP 7: Revision (Conditional)
+## REVISION: Revision (Conditional)
 
-**Goal**: Address evaluation feedback when STEP 6 results in FAIL.
+**Goal**: Address evaluation feedback when GATE:QUALITY results in FAIL.
 
 ### Activities
 - Review evaluation comments
 - Fix identified issues
 - Re-run tests
-- Request re-evaluation (back to STEP 6)
+- Request re-evaluation (back to GATE:QUALITY)
 
 ### Rules
 - Only address issues raised in the evaluation
@@ -382,7 +382,7 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 ---
 
-## STEP 8: PR & Review
+## SHIP: PR & Review
 
 **Goal**: Create a pull request for human review.
 
@@ -400,14 +400,14 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 ---
 
-## STEP 9: Merge & Close
+## LAND: Merge & Close
 
 **Goal**: Human merges the PR and closes the issue.
 
 ### This Step Is Human-Only
 - Human reviews the PR
 - Human approves or requests changes
-- If changes requested → return to STEP 7
+- If changes requested → return to REVISION
 - If approved → merge and close issue
 
 ### Exit Criteria
@@ -419,18 +419,18 @@ When spawning the Evaluation AI (at STEPs 1.5, 3, and 6), the orchestrator's pro
 
 ## Regression Rules
 
-When a STEP fails, the flow regresses — or terminates:
+When a phase fails, the flow regresses — or terminates:
 
 | Failure Point | Action | Reason |
 |--------------|--------|--------|
-| STEP 1.5 (structure eval FAIL) | **Close issue** | Existing structure already handles it |
-| STEP 3 (plan eval FAIL) | → STEP 2 (max 3x) | Plan revision needed |
-| STEP 5b↔5c cycle (tests fail) | → STEP 5b (max 3 round-trips) | Fix implementation or tests |
-| STEP 5d (refactor breaks tests) | Fix (max 2 attempts) | Keep pre-refactor state |
-| STEP 6 (score < 7.5) | → STEP 7 | Revision needed |
-| STEP 6 (consistency <= 3) | → STEP 4 | Mandatory major rework |
-| STEP 8 (CI fails) | → STEP 5a | Re-test |
-| STEP 9 (human rejects) | → STEP 7 | Address human feedback |
+| GATE:HYPOTHESIS (structure eval FAIL) | **Close issue** | Existing structure already handles it |
+| GATE:PLAN (plan eval FAIL) | → ARCHITECT (max 3x) | Plan revision needed |
+| GREEN↔VERIFY cycle (tests fail) | → GREEN (max 3 round-trips) | Fix implementation or tests |
+| REFINE (refactor breaks tests) | Fix (max 2 attempts) | Keep pre-refactor state |
+| GATE:QUALITY (score < 7.5) | → REVISION | Revision needed |
+| GATE:QUALITY (consistency <= 3) | → DISPATCH | Mandatory major rework |
+| SHIP (CI fails) | → RED | Re-test |
+| LAND (human rejects) | → REVISION | Address human feedback |
 
 ---
 
@@ -440,16 +440,16 @@ When a STEP fails, the flow regresses — or terminates:
 .autoflow-state/
 ├── current-issue          # Contains: issue number
 └── <issue-number>/
-    ├── step               # Contains: current step number
-    ├── requirements.md    # STEP 1 output (issue requirements)
+    ├── phase              # Contains: current phase name
+    ├── requirements.md    # DIAGNOSE output (issue requirements)
     ├── analysis/
     │   ├── phase-a.md     # Structure analysis
     │   ├── phase-b.md     # Issue analysis
     │   └── phase-3.md     # Cross-verification
-    ├── plan.md            # STEP 2 output
-    ├── delegation.md      # STEP 4 output (task assignments)
-    ├── evaluation.json    # STEP 6 output
-    └── history.log        # Step transition log
+    ├── plan.md            # ARCHITECT output
+    ├── delegation.md      # DISPATCH output (task assignments)
+    ├── evaluation.json    # GATE:QUALITY output
+    └── history.log        # Phase transition log
 ```
 
 > **Note**: Add `.autoflow-state/` to `.gitignore` — these are working files, not committed.

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -111,7 +111,7 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 
 **Goal**: Ensure only well-analyzed issues proceed to implementation. This gate is strict because insufficient analysis at this stage causes larger costs downstream.
 
-> **The Evaluation AI is spawned fresh** for this step — it carries no prior conversation history. This prevents self-reinforcement bias.
+> **The Evaluation AI is spawned fresh** for this phase — it carries no prior conversation history. This prevents self-reinforcement bias.
 
 ### Process
 1. A freshly spawned Evaluation AI receives: Phase A report, Phase B report, Phase 3 cross-verification
@@ -171,7 +171,7 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 
 **Goal**: An independent Evaluation AI scores the implementation plan before coding begins.
 
-> **The Evaluation AI is spawned fresh** for this step — it carries no prior conversation history.
+> **The Evaluation AI is spawned fresh** for this phase — it carries no prior conversation history.
 
 ### Process
 1. A freshly spawned Evaluation AI receives the implementation plan from ARCHITECT
@@ -404,7 +404,7 @@ When spawning the Evaluation AI (at GATE:HYPOTHESIS, GATE:PLAN, and GATE:QUALITY
 
 **Goal**: Human merges the PR and closes the issue.
 
-### This Step Is Human-Only
+### This Phase Is Human-Only
 - Human reviews the PR
 - Human approves or requests changes
 - If changes requested → return to REVISION

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -81,7 +81,7 @@ To bring the trust chain down to the script level. An AI can implicitly decide "
 
 **What this means**
 
-No matter how eloquently an AI says "the plan is excellent," if the scores don't meet the threshold, it cannot advance to the next step. The gate operates on numbers, not explanations.
+No matter how eloquently an AI says "the plan is excellent," if the scores don't meet the threshold, it cannot advance to the next phase. The gate operates on numbers, not explanations.
 
 ---
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -57,7 +57,7 @@ The suggestion "let's give AI-A the issue for efficiency" destroys the core of t
 
 **What it does**
 
-The Evaluation AI at STEPs 1.5, 3, 5.7, and 6 is created new for each invocation. It carries no prior conversation history.
+The Evaluation AI at GATE:HYPOTHESIS, GATE:PLAN, SHIP, and GATE:QUALITY is created new for each invocation. It carries no prior conversation history.
 
 **Why it works this way**
 
@@ -101,21 +101,21 @@ Analysis of pass/fail patterns, modification of evaluation criteria, and identif
 
 **However, factual lookups are different**
 
-Injecting past evaluation results (bias injection) and looking up past code change history or issue context (factual lookup) are different things. Querying related issues and commit history at STEP 1 is allowed because it serves to accurately understand the current state.
+Injecting past evaluation results (bias injection) and looking up past code change history or issue context (factual lookup) are different things. Querying related issues and commit history at DIAGNOSE is allowed because it serves to accurately understand the current state.
 
 ---
 
-### Decision 5: STEP Transitions Are Completion-Condition Based
+### Decision 5: Phase Transitions Are Completion-Condition Based
 
 **What it does**
 
-Each STEP transitions to the next only when its stated completion conditions are met. All STEPs are performed regardless of change size.
+Each phase transitions to the next only when its stated completion conditions are met. All phases are performed regardless of change size.
 
 **Why it works this way**
 
-AI tends to judge "this change is small enough to skip STEPs." That judgment itself is a product of bias. The thought "this one is simple" causes verification to be skipped, and problems emerge from the skipped verification. Simplicity can be determined after the process, not before it.
+AI tends to judge "this change is small enough to skip phases." That judgment itself is a product of bias. The thought "this one is simple" causes verification to be skipped, and problems emerge from the skipped verification. Simplicity can be determined after the process, not before it.
 
-The act of judging "this change is simple" is itself a product of bias. That judgment is made before implementation. Before implementation, there is no way to know whether it is actually simple. The judgment may sometimes be correct, but when it is wrong, problems emerge from the verification that was skipped. Auto-Flow does not permit this judgment at all. Simplicity can be evaluated post-hoc, after all STEPs are completed. Pre-process judgment is not allowed.
+The act of judging "this change is simple" is itself a product of bias. That judgment is made before implementation. Before implementation, there is no way to know whether it is actually simple. The judgment may sometimes be correct, but when it is wrong, problems emerge from the verification that was skipped. Auto-Flow does not permit this judgment at all. Simplicity can be evaluated post-hoc, after all phases are completed. Pre-process judgment is not allowed.
 
 ---
 
@@ -123,7 +123,7 @@ The act of judging "this change is simple" is itself a product of bias. That jud
 
 **What it does**
 
-When the structure evaluation at STEPs 1–2 returns FAIL, Auto-Flow terminates and the issue is closed. It means the existing structure can already handle the concern — no code change needed.
+When the structure evaluation at PREFLIGHT–DIAGNOSE returns FAIL, Auto-Flow terminates and the issue is closed. It means the existing structure can already handle the concern — no code change needed.
 
 **Why it works this way**
 
@@ -135,11 +135,11 @@ The best code is code that is never written. AI feels pressure to create somethi
 
 **What it does**
 
-Every repetition in Auto-Flow (e.g., STEP 5b↔5c test-fix cycles, STEP 7→6 re-evaluation cycles, STEP 9 revision requests) has an explicit maximum retry count. No loop can run indefinitely.
+Every repetition in Auto-Flow (e.g., GREEN↔VERIFY test-fix cycles, REVISION→GATE:QUALITY re-evaluation cycles, LAND revision requests) has an explicit maximum retry count. No loop can run indefinitely.
 
 **Why it works this way**
 
-When a loop fails, the work does not simply stop. The failure cause is classified, and the flow regresses to the appropriate STEP. When all retries are exhausted, the work is handed to a human. There is no scenario where a loop never terminates.
+When a loop fails, the work does not simply stop. The failure cause is classified, and the flow regresses to the appropriate phase. When all retries are exhausted, the work is handed to a human. There is no scenario where a loop never terminates.
 
 For comparison: review gate structures where two models find problems in each other's output (e.g., Codex-style mutual review) lack explicit termination conditions, creating infinite loop risk. Auto-Flow blocks this through three mechanisms: **maximum regression count + cause classification + defined human escalation point.**
 
@@ -159,9 +159,9 @@ The evaluation categories and weights in CLAUDE.md must be customized per projec
 
 Lenient criteria create a pattern of "scoring high on easy items to raise the average while passing difficult items." This is why individual minimum thresholds exist. The reason security score <= 3 triggers mandatory rework is the same — some items cannot be diluted by averaging.
 
-### The Role of Issue Analysis Evaluation (STEP 1.5)
+### The Role of Issue Analysis Evaluation (GATE:HYPOTHESIS)
 
-The purpose is to ensure only well-analyzed issues proceed to implementation. Entering implementation with insufficient analysis incurs greater costs later. The stricter this gate, the higher the quality of subsequent STEPs.
+The purpose is to ensure only well-analyzed issues proceed to implementation. Entering implementation with insufficient analysis incurs greater costs later. The stricter this gate, the higher the quality of subsequent phases.
 
 ---
 
@@ -175,7 +175,7 @@ The following may look like "better approaches" but undermine core principles:
 | Reuse the Evaluation AI | Self-reinforcement bias → independence lost |
 | Trust the Hook's `pass` field | Trusting AI self-report → gate neutralized |
 | Inject past evaluation results into current analysis | Bias propagation → system hardens in one direction |
-| Allow STEP-skipping judgment | "This one is simple" is itself a biased judgment |
+| Allow phase-skipping judgment | "This one is simple" is itself a biased judgment |
 | Let the pipeline modify its own criteria | Judgment tracing impossible → trust chain collapse |
 | Design loops without termination conditions | No maximum retry → infinite loop risk → system hangs |
 
@@ -187,11 +187,11 @@ The following may look like "better approaches" but undermine core principles:
 
 - **No failure learning loop**: Currently accumulated manually via issue comments. Pass/fail pattern analysis is performed by humans externally.
 - **No cross-issue correlation detection**: Cannot automatically detect repeated similar-pattern issues. Under internal discussion.
-- **No lightweight mode**: Full STEP execution even for small changes. Overhead exists.
+- **No lightweight mode**: Full phase execution even for small changes. Overhead exists.
 
 ### Under Discussion
 
-- Including related issue and commit history lookup at STEP 1 entry (factual lookup, not bias injection)
+- Including related issue and commit history lookup at DIAGNOSE entry (factual lookup, not bias injection)
 - Systematizing issue preparation stages through external cross-issue correlation analysis
 
 ---

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -1,6 +1,6 @@
 # Evaluation System
 
-> The Auto-Flow evaluation system provides quantified quality assessment at STEPs 1.5 and 6, ensuring consistent standards across all changes.
+> The Auto-Flow evaluation system provides quantified quality assessment at GATE:HYPOTHESIS and GATE:QUALITY, ensuring consistent standards across all changes.
 
 ---
 
@@ -10,7 +10,7 @@ The Evaluation AI is an **independent agent** that scores completed work before 
 
 ### Critical Rule: Fresh Spawn Every Time
 
-**The Evaluation AI must be spawned fresh for every evaluation** — at STEPs 1.5, 3, and 6. It carries no prior conversation history. This is mandatory, not optional.
+**The Evaluation AI must be spawned fresh for every evaluation** — at GATE:HYPOTHESIS, GATE:PLAN, and GATE:QUALITY. It carries no prior conversation history. This is mandatory, not optional.
 
 **Why**: When the same agent creates a plan and evaluates it, it struggles to reject its own work. A freshly spawned agent sees only the deliverable — it has no investment in the process. Bias elimination takes priority over token cost savings. See [docs/design-rationale.md](design-rationale.md#decision-2-evaluation-ai-is-spawned-fresh-every-time).
 
@@ -51,9 +51,9 @@ Lenient criteria create a pattern of "scoring high on easy categories to raise t
 
 | Condition | Result | Action |
 |-----------|--------|--------|
-| Consistency <= 3 | AUTO-FAIL | → STEP 4 (mandatory major rework) |
-| Any category < 7 | FAIL | → STEP 7 (revision) |
-| Overall < 7.5 | FAIL | → STEP 7 (revision) |
+| Consistency <= 3 | AUTO-FAIL | → DISPATCH (mandatory major rework) |
+| Any category < 7 | FAIL | → REVISION |
+| Overall < 7.5 | FAIL | → REVISION |
 
 ---
 
@@ -112,7 +112,7 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
 
 ```json
 {
-  "step": 6,
+  "phase": "GATE:QUALITY",
   "issue": "#123",
   "evaluator": "evaluation-ai",
   "timestamp": "2025-01-15T10:30:00Z",
@@ -135,7 +135,7 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `step` | number | Always `6` for evaluation |
+| `phase` | string | Always `"GATE:QUALITY"` for evaluation |
 | `issue` | string | Issue reference (e.g., "#123") |
 | `evaluator` | string | Agent identifier |
 | `timestamp` | string | ISO 8601 timestamp |
@@ -155,7 +155,7 @@ The Evaluation AI receives:
 1. **Issue requirements** (`.autoflow-state/<issue>/requirements.md`)
 2. **Implementation plan** (`.autoflow-state/<issue>/plan.md`)
 3. **Code diff** (`git diff` of the changes)
-4. **Test results** (test output from STEP 5c)
+4. **Test results** (test output from VERIFY)
 
 ### Evaluation Steps
 
@@ -172,9 +172,9 @@ The Evaluation AI receives:
 
 ---
 
-## Re-Evaluation (After STEP 7)
+## Re-Evaluation (After REVISION)
 
-When a change fails and goes through STEP 7 (revision):
+When a change fails and goes through REVISION:
 
 1. A **freshly spawned** Evaluation AI receives the **updated** diff and test results
 2. It also receives the **previous evaluation** for context
@@ -186,7 +186,7 @@ When a change fails and goes through STEP 7 (revision):
 ### Maximum Revision Cycles
 
 - **3 revision cycles maximum** before human escalation
-- Each cycle: STEP 7 (revision) → STEP 6 (re-evaluation)
+- Each cycle: REVISION → GATE:QUALITY (re-evaluation)
 - If still failing after 3 cycles, the Orchestrator escalates to a human with all evaluation reports
 
 ---

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -157,7 +157,7 @@ The Evaluation AI receives:
 3. **Code diff** (`git diff` of the changes)
 4. **Test results** (test output from VERIFY)
 
-### Evaluation Steps
+### Evaluation Process
 
 1. **Read** all inputs thoroughly
 2. **Verify correctness** against requirements

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -76,7 +76,7 @@ Refs: #87
 
 ## Pull Request Process
 
-### Creating a PR (STEP 8)
+### Creating a PR (SHIP)
 
 1. Ensure all commits are clean and well-described
 2. Push the feature branch to remote

--- a/docs/repo-boundary-rules.md
+++ b/docs/repo-boundary-rules.md
@@ -130,7 +130,7 @@ Orchestrator → Frontend AI:
 When two repos need changes that conflict (e.g., incompatible interface changes):
 
 1. **Detect**: Orchestrator identifies the conflict during coordination
-2. **Pause**: Both repos pause their Auto-Flow at current STEP
+2. **Pause**: Both repos pause their Auto-Flow at current phase
 3. **Resolve**: Orchestrator proposes resolution via Discussion Protocol
 4. **Agree**: Resolution documented and agreed upon
 5. **Resume**: Repos resume with the agreed approach

--- a/docs/submodule-common-rules.md
+++ b/docs/submodule-common-rules.md
@@ -56,7 +56,7 @@ For cross-repo changes, raise a Discussion to the Orchestrator.
 This repository follows the Auto-Flow lifecycle defined in:
 {{GITHUB_ORG}}/{{REPO_ORCHESTRATOR}}/CLAUDE.md
 
-All STEPs, evaluation criteria, and gate rules apply.
+All Auto-Flow phases, evaluation criteria, and gate rules apply.
 ```
 
 ---
@@ -64,16 +64,16 @@ All STEPs, evaluation criteria, and gate rules apply.
 ## Agent Behavior Rules
 
 ### DO
-- Follow the Auto-Flow STEPs in order
-- Run tests before marking STEP 5 complete
+- Follow the Auto-Flow phases in order
+- Run tests before marking the TDD cycle complete
 - Use the Discussion Protocol for ambiguities
 - Reference the orchestrator's CLAUDE.md for process questions
 
 ### DO NOT
-- Skip the evaluation gate (STEP 6)
+- Skip the evaluation gate (GATE:QUALITY)
 - Modify files in other repositories
 - Push directly to `{{DEFAULT_BRANCH}}`
-- Ignore evaluation feedback during revision (STEP 7)
+- Ignore evaluation feedback during revision (REVISION)
 
 ---
 
@@ -135,5 +135,5 @@ Each sub-repo should have CI that:
 ### Auto-Flow Gate Integration
 The `check-autoflow-gate.sh` hook can be integrated into CI to verify:
 - Evaluation score meets threshold
-- All STEPs completed in order
+- All Auto-Flow phases completed in order
 - State files are consistent

--- a/tests/test-check-autoflow-gate.sh
+++ b/tests/test-check-autoflow-gate.sh
@@ -72,14 +72,14 @@ cleanup_test_dir() {
   fi
 }
 
-# Set up mock autoflow-state with a given step and evaluation JSON
+# Set up mock autoflow-state with a given phase and evaluation JSON
 setup_eval_fixture() {
-  local step="$1"
+  local phase="$1"
   local eval_json="$2"
   local issue="99"
   mkdir -p "${TEST_DIR}/.autoflow-state/${issue}"
   echo "$issue" > "${TEST_DIR}/.autoflow-state/current-issue"
-  echo "$step" > "${TEST_DIR}/.autoflow-state/${issue}/step"
+  echo "$phase" > "${TEST_DIR}/.autoflow-state/${issue}/phase"
   # Create delegation.md so delegation gate doesn't block
   cat > "${TEST_DIR}/.autoflow-state/${issue}/delegation.md" <<'EOF'
 ## Team
@@ -116,8 +116,8 @@ echo ""
 echo "--- GROUP 1: Dynamic enumeration with standard CLAUDE.md categories ---"
 
 setup_test_dir
-setup_eval_fixture 6 '{
-  "step": 6,
+setup_eval_fixture "GATE:QUALITY" '{
+  "phase": "GATE:QUALITY",
   "issue": "#99",
   "scores": {
     "correctness": { "score": 9, "reason": "Meets all requirements" },
@@ -142,8 +142,8 @@ echo ""
 echo "--- GROUP 2: Dynamic enumeration with custom categories ---"
 
 setup_test_dir
-setup_eval_fixture 6 '{
-  "step": 6,
+setup_eval_fixture "GATE:QUALITY" '{
+  "phase": "GATE:QUALITY",
   "issue": "#99",
   "scores": {
     "accessibility": { "score": 9, "reason": "WCAG compliant" },
@@ -162,7 +162,7 @@ echo ""
 
 # Test with a single category
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "overall_quality": { "score": 9, "reason": "Excellent" }
   }
@@ -176,7 +176,7 @@ echo ""
 
 # Test with many categories
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_a": 8,
     "cat_b": 8,
@@ -200,7 +200,7 @@ echo ""
 echo "--- GROUP 3: Dual format — flat ---"
 
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 9,
     "quality": 8,
@@ -222,7 +222,7 @@ echo ""
 echo "--- GROUP 4: Dual format — structured ---"
 
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": { "score": 9, "reason": "All requirements met" },
     "quality": { "score": 8, "reason": "Clean" },
@@ -244,7 +244,7 @@ echo ""
 echo "--- GROUP 5: Dual format — mixed ---"
 
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 9,
     "quality": { "score": 8, "reason": "Clean code" },
@@ -269,7 +269,7 @@ echo "--- GROUP 6: Weight configuration with weights.json ---"
 # correctness=10 (weight 0.5), quality=6 (weight 0.5) → avg = 8.0 → PASS
 # BUT quality=6 < 7 → FAIL due to individual minimum
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 6
@@ -291,7 +291,7 @@ echo ""
 # With weights.json: heavy weight on high-scoring category pulls average up
 # correctness=10 (weight 0.9), quality=7 (weight 0.1) → weighted avg = 9.7 → PASS
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 7
@@ -314,7 +314,7 @@ echo ""
 # correctness=7 (weight 0.1), quality=10 (weight 0.9) → weighted avg = 9.7 → PASS
 # correctness=7 (weight 0.9), quality=10 (weight 0.1) → weighted avg = 7.3 → FAIL (<7.5)
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 7,
     "quality": 10
@@ -340,7 +340,7 @@ echo "--- GROUP 7: Without weights.json → equal weights ---"
 
 # 3 categories at 8 each → avg = 8.0 → PASS
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_x": 8,
     "cat_y": 8,
@@ -356,7 +356,7 @@ echo ""
 
 # 2 categories: one at 10, one at 7 → equal avg = 8.5 → PASS (both >= 7)
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "alpha": 10,
     "beta": 7
@@ -371,7 +371,7 @@ echo ""
 
 # 2 categories: one at 10, one at 5 → equal avg = 7.5 → but 5 < 7 → FAIL
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "alpha": 10,
     "beta": 5
@@ -391,7 +391,7 @@ echo "--- GROUP 8: Auto-fail with default key (consistency) ---"
 
 # consistency <= 3 → AUTO-FAIL regardless of other scores
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 10,
@@ -411,7 +411,7 @@ echo ""
 
 # consistency = 2 → AUTO-FAIL
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 10,
@@ -429,7 +429,7 @@ echo ""
 
 # consistency = 4 → NOT auto-fail (but still below 7, so FAIL for min check)
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 10,
@@ -449,7 +449,7 @@ echo ""
 
 # consistency = 8 → no auto-fail, passes fine
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 8,
     "quality": 8,
@@ -472,7 +472,7 @@ echo "--- GROUP 9: Custom AUTO_FAIL_KEY ---"
 
 # Custom auto-fail key: "reliability" at <=3 → AUTO-FAIL
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "reliability": 3,
@@ -491,7 +491,7 @@ echo ""
 # Custom auto-fail key: consistency is no longer the auto-fail key
 # So consistency=2 does NOT trigger auto-fail (but still fails min check)
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "consistency": 2,
@@ -509,7 +509,7 @@ echo ""
 
 # Non-existent auto-fail key → no auto-fail triggered at all
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 8,
     "quality": 8,
@@ -530,7 +530,7 @@ echo "--- GROUP 10: Pass/fail edge cases ---"
 
 # All scores exactly 7.5 → avg=7.5, all>=7 → PASS
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_a": 7.5,
     "cat_b": 7.5,
@@ -546,7 +546,7 @@ echo ""
 
 # One category at exactly 7, rest at 8 → avg=7.75, all>=7 → PASS
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_a": 8,
     "cat_b": 7,
@@ -563,7 +563,7 @@ echo ""
 
 # One category at 6.9 → below individual minimum → FAIL
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_a": 9,
     "cat_b": 6.9,
@@ -581,7 +581,7 @@ echo ""
 # 3 categories: 7, 7, 7.47 → avg ≈ 7.157 → FAIL
 # Better: 2 categories: 7, 7.98 → avg = 7.49 → FAIL
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "cat_a": 7,
     "cat_b": 7.98
@@ -596,7 +596,7 @@ echo ""
 
 # All perfect 10s → PASS
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 10,
     "quality": 10,
@@ -619,7 +619,7 @@ echo "--- GROUP 11: Backward compatibility with old flat format ---"
 
 # The old hardcoded categories in flat format should still work
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 9,
     "code_quality": 8,
@@ -639,7 +639,7 @@ echo ""
 # NOTE: In the NEW system, auto-fail key defaults to "consistency", not "security"
 # So old-style "security" at 2 should NOT trigger auto-fail (but fails min check)
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": 9,
     "code_quality": 8,
@@ -752,12 +752,12 @@ fi
 echo ""
 
 # ==========================================================================
-# GROUP 16: STEP 8 also uses dynamic evaluation
+# GROUP 16: SHIP also uses dynamic evaluation
 # ==========================================================================
-echo "--- GROUP 16: STEP 8 uses same dynamic evaluation ---"
+echo "--- GROUP 16: SHIP uses same dynamic evaluation ---"
 
 setup_test_dir
-setup_eval_fixture 8 '{
+setup_eval_fixture "SHIP" '{
   "scores": {
     "custom_a": { "score": 9, "reason": "Good" },
     "custom_b": { "score": 8, "reason": "Fine" }
@@ -765,13 +765,13 @@ setup_eval_fixture 8 '{
 }'
 exit_code=$(run_hook)
 assert_exit_code 0 "$exit_code" \
-  "T40: STEP 8 with custom categories → PASS"
+  "T40: SHIP with custom categories → PASS"
 cleanup_test_dir
 
 echo ""
 
 setup_test_dir
-setup_eval_fixture 8 '{
+setup_eval_fixture "SHIP" '{
   "scores": {
     "custom_a": { "score": 9, "reason": "Good" },
     "custom_b": { "score": 5, "reason": "Poor" }
@@ -779,7 +779,7 @@ setup_eval_fixture 8 '{
 }'
 exit_code=$(run_hook)
 assert_exit_code 1 "$exit_code" \
-  "T41: STEP 8 with one low custom category → FAIL"
+  "T41: SHIP with one low custom category → FAIL"
 cleanup_test_dir
 
 echo ""
@@ -791,7 +791,7 @@ echo "--- GROUP 17: extract_score handles structured format ---"
 
 # Structured format with "score" key nested inside an object
 setup_test_dir
-setup_eval_fixture 6 '{
+setup_eval_fixture "GATE:QUALITY" '{
   "scores": {
     "correctness": { "score": 5, "reason": "Incomplete implementation" },
     "quality": { "score": 5, "reason": "Messy" },

--- a/tests/test-delegation-gate.sh
+++ b/tests/test-delegation-gate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Test Suite: Delegation Gate for STEP 4 (Issue #16)
+# Test Suite: Delegation Gate for DISPATCH (Issue #16)
 # Validates that delegation.md is enforced as a mandatory artifact
-# before STEP 5a can begin, across documentation and hook logic.
+# before RED can begin, across documentation and hook logic.
 
 set -euo pipefail
 
@@ -38,29 +38,29 @@ CLAUDE_MD="CLAUDE.md"
 GUIDE="docs/autoflow-guide.md"
 HOOK=".claude/hooks/check-autoflow-gate.sh"
 
-echo "=== Test Suite: Delegation Gate for STEP 4 (Issue #16) ==="
+echo "=== Test Suite: Delegation Gate for DISPATCH (Issue #16) ==="
 echo ""
 
 # ==========================================================================
-# AC1: CLAUDE.md.template STEP 4 section mentions delegation.md as mandatory
+# AC1: CLAUDE.md.template DISPATCH section mentions delegation.md as mandatory
 # ==========================================================================
-echo "--- AC1: STEP 4 mentions delegation.md as mandatory ---"
+echo "--- AC1: DISPATCH mentions delegation.md as mandatory ---"
 
 assert_contains "$TEMPLATE" "delegation\.md" \
-  "T1: CLAUDE.md.template STEP 4 section references delegation.md"
+  "T1: CLAUDE.md.template DISPATCH section references delegation.md"
 
 assert_contains "$TEMPLATE" "delegation\.md.*mandatory\|[MUST].*delegation\.md\|\[MUST\].*delegation" \
-  "T2: CLAUDE.md.template marks delegation.md as mandatory in STEP 4"
+  "T2: CLAUDE.md.template marks delegation.md as mandatory in DISPATCH"
 
 echo ""
 
 # ==========================================================================
-# AC2: CLAUDE.md.template STEP 5a mentions delegation.md as entry precondition
+# AC2: CLAUDE.md.template RED mentions delegation.md as entry precondition
 # ==========================================================================
-echo "--- AC2: STEP 5a mentions delegation.md as precondition ---"
+echo "--- AC2: RED mentions delegation.md as precondition ---"
 
 assert_contains "$TEMPLATE" "delegation\.md.*precondition\|delegation\.md.*before\|delegation\.md.*exists\|delegation\.md.*entry" \
-  "T3: CLAUDE.md.template STEP 5a references delegation.md as entry requirement"
+  "T3: CLAUDE.md.template RED references delegation.md as entry requirement"
 
 echo ""
 
@@ -83,12 +83,12 @@ assert_contains "$TEMPLATE" "Developer AI Instructions\|dev-ai.*instructions\|De
 echo ""
 
 # ==========================================================================
-# AC4: Flow Control Table includes delegation.md in STEP 4 condition
+# AC4: Flow Control Table includes delegation.md in DISPATCH condition
 # ==========================================================================
 echo "--- AC4: Flow Control Table updated ---"
 
-assert_contains "$TEMPLATE" "STEP 4.*delegation\.md\|delegation\.md.*STEP 4" \
-  "T7: Flow Control table mentions delegation.md for STEP 4"
+assert_contains "$TEMPLATE" "DISPATCH.*delegation\.md\|delegation\.md.*DISPATCH" \
+  "T7: Flow Control table mentions delegation.md for DISPATCH"
 
 echo ""
 
@@ -129,48 +129,48 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 
 # Set up mock autoflow-state directory
 setup_mock_state() {
-  local step="$1"
+  local phase="$1"
   local issue="99"
   mkdir -p "${TEST_DIR}/.autoflow-state/${issue}"
   echo "$issue" > "${TEST_DIR}/.autoflow-state/current-issue"
-  echo "$step" > "${TEST_DIR}/.autoflow-state/${issue}/step"
+  echo "$phase" > "${TEST_DIR}/.autoflow-state/${issue}/phase"
 }
 
-# AC7: Hook validates delegation.md existence at STEP >= 5
+# AC7: Hook validates delegation.md existence at RED phase and beyond
 echo ""
-echo "  --- AC7: Hook checks delegation.md at STEP >= 5 ---"
+echo "  --- AC7: Hook checks delegation.md at RED phase and beyond ---"
 
-setup_mock_state 5
-CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-step5.txt" 2>&1 || true
-if grep -qi "delegation" "${TEST_DIR}/output-step5.txt" 2>/dev/null; then
+setup_mock_state RED
+CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-phase-red.txt" 2>&1 || true
+if grep -qi "delegation" "${TEST_DIR}/output-phase-red.txt" 2>/dev/null; then
   PASS=$((PASS + 1))
-  echo "  PASS: T12: Hook mentions delegation.md when checking STEP 5"
+  echo "  PASS: T12: Hook mentions delegation.md when checking RED phase"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("FAIL: T12: Hook does not mention delegation.md at STEP 5")
-  echo "  FAIL: T12: Hook mentions delegation.md when checking STEP 5"
+  ERRORS+=("FAIL: T12: Hook does not mention delegation.md at RED phase")
+  echo "  FAIL: T12: Hook mentions delegation.md when checking RED phase"
 fi
 
-# AC8: Hook exits 1 with clear error when delegation.md missing at STEP >= 5
+# AC8: Hook exits 1 with clear error when delegation.md missing at RED phase
 echo ""
 echo "  --- AC8: Hook exits 1 when delegation.md missing ---"
 
-setup_mock_state 5
+setup_mock_state RED
 # Ensure no delegation.md exists
 rm -f "${TEST_DIR}/.autoflow-state/99/delegation.md"
 hook_exit=0
 CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-missing.txt" 2>&1 || hook_exit=$?
 if [ "$hook_exit" -eq 1 ]; then
   PASS=$((PASS + 1))
-  echo "  PASS: T13: Hook exits 1 when delegation.md is missing at STEP 5"
+  echo "  PASS: T13: Hook exits 1 when delegation.md is missing at RED phase"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("FAIL: T13: Hook exits 0 (should exit 1) when delegation.md is missing at STEP 5 (got exit $hook_exit)")
-  echo "  FAIL: T13: Hook exits 1 when delegation.md is missing at STEP 5"
+  ERRORS+=("FAIL: T13: Hook exits 0 (should exit 1) when delegation.md is missing at RED phase (got exit $hook_exit)")
+  echo "  FAIL: T13: Hook exits 1 when delegation.md is missing at RED phase"
 fi
 
-# Also test STEP 6 (should also require delegation.md)
-setup_mock_state 6
+# Also test GATE:QUALITY (should also require delegation.md)
+setup_mock_state "GATE:QUALITY"
 rm -f "${TEST_DIR}/.autoflow-state/99/delegation.md"
 # Create a passing evaluation.json so the eval gate doesn't mask the delegation check
 mkdir -p "${TEST_DIR}/.autoflow-state/99"
@@ -186,40 +186,40 @@ cat > "${TEST_DIR}/.autoflow-state/99/evaluation.json" <<'EJSON'
 }
 EJSON
 hook_exit_6=0
-CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-step6-nodelegation.txt" 2>&1 || hook_exit_6=$?
-if grep -qi "delegation" "${TEST_DIR}/output-step6-nodelegation.txt" 2>/dev/null; then
+CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-phase-gate-quality-nodelegation.txt" 2>&1 || hook_exit_6=$?
+if grep -qi "delegation" "${TEST_DIR}/output-phase-gate-quality-nodelegation.txt" 2>/dev/null; then
   PASS=$((PASS + 1))
-  echo "  PASS: T14: Hook checks delegation.md at STEP 6"
+  echo "  PASS: T14: Hook checks delegation.md at GATE:QUALITY"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("FAIL: T14: Hook does not check delegation.md at STEP 6")
-  echo "  FAIL: T14: Hook checks delegation.md at STEP 6"
+  ERRORS+=("FAIL: T14: Hook does not check delegation.md at GATE:QUALITY")
+  echo "  FAIL: T14: Hook checks delegation.md at GATE:QUALITY"
 fi
 
-# AC9: STEP 0-4 commits still work without delegation.md (no regression)
+# AC9: PREFLIGHT/DIAGNOSE/ARCHITECT/GATE:PLAN/DISPATCH commits still work without delegation.md (no regression)
 echo ""
-echo "  --- AC9: No regression for STEP 0-4 ---"
+echo "  --- AC9: No regression for pre-RED phases ---"
 
-for s in 0 1 2 3 4; do
+for s in PREFLIGHT DIAGNOSE ARCHITECT "GATE:PLAN" DISPATCH; do
   setup_mock_state "$s"
   rm -f "${TEST_DIR}/.autoflow-state/99/delegation.md"
-  step_exit=0
-  CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-step${s}.txt" 2>&1 || step_exit=$?
-  if [ "$step_exit" -eq 0 ]; then
+  phase_exit=0
+  CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-phase-${s}.txt" 2>&1 || phase_exit=$?
+  if [ "$phase_exit" -eq 0 ]; then
     PASS=$((PASS + 1))
-    echo "  PASS: T15-${s}: Hook passes at STEP ${s} without delegation.md"
+    echo "  PASS: T15-${s}: Hook passes at ${s} without delegation.md"
   else
     FAIL=$((FAIL + 1))
-    ERRORS+=("FAIL: T15-${s}: Hook fails at STEP ${s} without delegation.md (exit $step_exit)")
-    echo "  FAIL: T15-${s}: Hook passes at STEP ${s} without delegation.md"
+    ERRORS+=("FAIL: T15-${s}: Hook fails at ${s} without delegation.md (exit $phase_exit)")
+    echo "  FAIL: T15-${s}: Hook passes at ${s} without delegation.md"
   fi
 done
 
-# Bonus: Hook passes at STEP 5 when delegation.md EXISTS
+# Bonus: Hook passes at RED when delegation.md EXISTS
 echo ""
 echo "  --- Bonus: Hook passes when delegation.md is present ---"
 
-setup_mock_state 5
+setup_mock_state RED
 cat > "${TEST_DIR}/.autoflow-state/99/delegation.md" <<'DELEG'
 ## Team
 issue-16-team
@@ -231,14 +231,14 @@ Write tests for acceptance criteria.
 Implement minimum code to pass tests.
 DELEG
 hook_exit_with=0
-CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-step5-with.txt" 2>&1 || hook_exit_with=$?
+CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" > "${TEST_DIR}/output-phase-red-with.txt" 2>&1 || hook_exit_with=$?
 if [ "$hook_exit_with" -eq 0 ]; then
   PASS=$((PASS + 1))
-  echo "  PASS: T16: Hook passes at STEP 5 when delegation.md exists"
+  echo "  PASS: T16: Hook passes at RED when delegation.md exists"
 else
   FAIL=$((FAIL + 1))
-  ERRORS+=("FAIL: T16: Hook passes at STEP 5 when delegation.md exists (got exit $hook_exit_with)")
-  echo "  FAIL: T16: Hook passes at STEP 5 when delegation.md exists"
+  ERRORS+=("FAIL: T16: Hook passes at RED when delegation.md exists (got exit $hook_exit_with)")
+  echo "  FAIL: T16: Hook passes at RED when delegation.md exists"
 fi
 
 echo ""
@@ -251,13 +251,13 @@ echo "--- AC10: CLAUDE.md synced with template ---"
 assert_contains "$CLAUDE_MD" "delegation\.md" \
   "T17: CLAUDE.md references delegation.md"
 
-# CLAUDE.md STEP 4 should mention delegation.md
-assert_contains "$CLAUDE_MD" "STEP 4.*delegation\|delegation.*STEP 4\|## STEP 4" \
-  "T18: CLAUDE.md STEP 4 section exists (baseline)"
+# CLAUDE.md DISPATCH should mention delegation.md
+assert_contains "$CLAUDE_MD" "DISPATCH.*delegation\|delegation.*DISPATCH\|## DISPATCH" \
+  "T18: CLAUDE.md DISPATCH section exists (baseline)"
 
 # Check that CLAUDE.md Flow Control also reflects delegation.md
-assert_contains "$CLAUDE_MD" "delegation\.md.*STEP 4\|STEP 4.*delegation" \
-  "T19: CLAUDE.md Flow Control references delegation.md for STEP 4"
+assert_contains "$CLAUDE_MD" "delegation\.md.*DISPATCH\|DISPATCH.*delegation" \
+  "T19: CLAUDE.md Flow Control references delegation.md for DISPATCH"
 
 echo ""
 

--- a/tests/test-step0-restoration.sh
+++ b/tests/test-step0-restoration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Test Suite: STEP 0 Pre-Work Restoration (Issue #5)
-# Validates that STEP 0 is "Pre-Work" (Git Clean Check) across all docs
+# Test Suite: PREFLIGHT Pre-Work Restoration (Issue #5)
+# Validates that PREFLIGHT is "Pre-Work" (Git Clean Check) across all docs
 
 set -euo pipefail
 
@@ -37,78 +37,78 @@ GUIDE="docs/autoflow-guide.md"
 README="README.md"
 EVAL_SYSTEM="docs/evaluation-system.md"
 
-echo "=== Test Suite: STEP 0 Pre-Work Restoration ==="
+echo "=== Test Suite: PREFLIGHT Pre-Work Restoration ==="
 echo ""
 
 # --- CLAUDE.md.template tests ---
 echo "--- CLAUDE.md.template ---"
 
 assert_contains "$TEMPLATE" "Pre-Work" \
-  "T1: CLAUDE.md.template STEP 0 contains 'Pre-Work'"
+  "T1: CLAUDE.md.template PREFLIGHT contains 'Pre-Work'"
 
 assert_contains "$TEMPLATE" "git status" \
-  "T2: CLAUDE.md.template STEP 0 includes git status check"
+  "T2: CLAUDE.md.template PREFLIGHT includes git status check"
 
 assert_contains "$TEMPLATE" "git fetch" \
-  "T3: CLAUDE.md.template STEP 0 includes git fetch"
+  "T3: CLAUDE.md.template PREFLIGHT includes git fetch"
 
-assert_not_contains "$TEMPLATE" "| 0 | \*\*Issue Analysis\*\*" \
-  "T4: CLAUDE.md.template STEP 0 is NOT 'Issue Analysis'"
+assert_not_contains "$TEMPLATE" "| PREFLIGHT | \*\*Issue Analysis\*\*" \
+  "T4: CLAUDE.md.template PREFLIGHT is NOT 'Issue Analysis'"
 
 assert_contains "$TEMPLATE" "Git clean.*branch created\|branch created.*Git clean" \
-  "T5: CLAUDE.md.template Flow Control shows STEP 0 exit as git clean + branch"
+  "T5: CLAUDE.md.template Flow Control shows PREFLIGHT exit as git clean + branch"
 
 # --- docs/autoflow-guide.md tests ---
 echo ""
 echo "--- docs/autoflow-guide.md ---"
 
 assert_contains "$GUIDE" "Pre-Work" \
-  "T6: autoflow-guide.md STEP 0 contains 'Pre-Work'"
+  "T6: autoflow-guide.md PREFLIGHT contains 'Pre-Work'"
 
 assert_contains "$GUIDE" "git status" \
-  "T7: autoflow-guide.md STEP 0 includes git status check"
+  "T7: autoflow-guide.md PREFLIGHT includes git status check"
 
 assert_contains "$GUIDE" "git fetch" \
-  "T8: autoflow-guide.md STEP 0 includes git fetch"
+  "T8: autoflow-guide.md PREFLIGHT includes git fetch"
 
-assert_not_contains "$GUIDE" "## STEP 0: Issue Analysis" \
-  "T9: autoflow-guide.md STEP 0 is NOT titled 'Issue Analysis'"
+assert_not_contains "$GUIDE" "## PREFLIGHT: Issue Analysis" \
+  "T9: autoflow-guide.md PREFLIGHT is NOT titled 'Issue Analysis'"
 
 # --- README.md tests ---
 echo ""
 echo "--- README.md ---"
 
-assert_contains "$README" "STEP 0.*Pre-Work\|STEP 0.*Git Clean" \
-  "T10: README.md STEP 0 shows Pre-Work or Git Clean Check"
+assert_contains "$README" "PREFLIGHT.*Pre-Work\|PREFLIGHT.*Git Clean" \
+  "T10: README.md PREFLIGHT shows Pre-Work or Git Clean Check"
 
-assert_not_contains "$README" "STEP 0.*Issue Analysis" \
-  "T11: README.md STEP 0 is NOT 'Issue Analysis'"
+assert_not_contains "$README" "PREFLIGHT.*Issue Analysis" \
+  "T11: README.md PREFLIGHT is NOT 'Issue Analysis'"
 
 # --- Cross-file consistency ---
 echo ""
 echo "--- Cross-file consistency ---"
 
-assert_not_contains "$TEMPLATE" "| STEP 0 | Issue analyzed" \
-  "T12: Flow Control table does not reference 'Issue analyzed' for STEP 0"
+assert_not_contains "$TEMPLATE" "| PREFLIGHT | Issue analyzed" \
+  "T12: Flow Control table does not reference 'Issue analyzed' for PREFLIGHT"
 
 # --- Evaluation system unchanged ---
 echo ""
 echo "--- Evaluation system ---"
 
-# evaluation-system.md should not define STEP 0 content at all
-assert_not_contains "$EVAL_SYSTEM" "STEP 0" \
-  "T13: evaluation-system.md does not reference STEP 0"
+# evaluation-system.md should not define PREFLIGHT content at all
+assert_not_contains "$EVAL_SYSTEM" "PREFLIGHT" \
+  "T13: evaluation-system.md does not reference PREFLIGHT"
 
-# --- STEP 1 absorbs issue understanding ---
+# --- DIAGNOSE absorbs issue understanding ---
 echo ""
-echo "--- STEP 1 absorption ---"
+echo "--- DIAGNOSE absorption ---"
 
-assert_contains "$GUIDE" "## STEP 1" \
-  "T14: autoflow-guide.md has STEP 1 section"
+assert_contains "$GUIDE" "## DIAGNOSE" \
+  "T14: autoflow-guide.md has DIAGNOSE section"
 
-# State file structure: requirements.md annotation should reference Pre-Work or STEP 0-1
-assert_not_contains "$GUIDE" "requirements.md.*# STEP 0 output" \
-  "T15: State file annotation does not label requirements.md as 'STEP 0 output' specifically"
+# State file structure: requirements.md annotation should reference Pre-Work or PREFLIGHT/DIAGNOSE
+assert_not_contains "$GUIDE" "requirements.md.*# PREFLIGHT output" \
+  "T15: State file annotation does not label requirements.md as 'PREFLIGHT output' specifically"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="

--- a/tests/test-tdd-cycle-restoration.sh
+++ b/tests/test-tdd-cycle-restoration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: TDD Cycle Restoration (Issue #4)
-# Verifies STEP 5a/5b/5c/5d sub-steps are present in template files.
+# Verifies RED/GREEN/VERIFY/REFINE sub-steps are present in template files.
 # All tests should FAIL (Red) before implementation.
 
 set -euo pipefail
@@ -25,94 +25,94 @@ fail() {
   FAIL_COUNT=$((FAIL_COUNT + 1))
 }
 
-# ---------- AC 1: Lifecycle table STEP 3 = "Plan Evaluation" ----------
+# ---------- AC 1: Lifecycle table GATE:PLAN = "Plan Evaluation" ----------
 test_ac1_step3_plan_evaluation() {
-  echo "AC1: CLAUDE.md.template lifecycle table shows STEP 3 as Plan Evaluation"
-  # Look for a table row with STEP 3 and "Plan Evaluation" (not "Implementation")
-  if grep -E '^\| *3 .*Plan Evaluation' "$TEMPLATE" >/dev/null 2>&1; then
-    pass "STEP 3 is Plan Evaluation"
+  echo "AC1: CLAUDE.md.template lifecycle table shows GATE:PLAN as Plan Evaluation"
+  # Look for a table row with GATE:PLAN and "Plan Evaluation" (not "Implementation")
+  if grep -E '^\| *GATE:PLAN .*Plan Evaluation' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "GATE:PLAN is Plan Evaluation"
   else
-    fail "STEP 3 is not Plan Evaluation in lifecycle table"
+    fail "GATE:PLAN is not Plan Evaluation in lifecycle table"
   fi
 }
 
-# ---------- AC 2: Lifecycle table STEP 4 = "Task Assignment" ----------
+# ---------- AC 2: Lifecycle table DISPATCH = "Task Assignment" ----------
 test_ac2_step4_task_assignment() {
-  echo "AC2: CLAUDE.md.template lifecycle table shows STEP 4 as Task Assignment"
-  if grep -E '^\| *4 .*Task Assignment' "$TEMPLATE" >/dev/null 2>&1; then
-    pass "STEP 4 is Task Assignment"
+  echo "AC2: CLAUDE.md.template lifecycle table shows DISPATCH as Task Assignment"
+  if grep -E '^\| *DISPATCH .*Task Assignment' "$TEMPLATE" >/dev/null 2>&1; then
+    pass "DISPATCH is Task Assignment"
   else
-    fail "STEP 4 is not Task Assignment in lifecycle table"
+    fail "DISPATCH is not Task Assignment in lifecycle table"
   fi
 }
 
-# ---------- AC 3: Template contains STEP 5a, 5b, 5c, 5d references ----------
+# ---------- AC 3: Template contains RED, GREEN, VERIFY, REFINE references ----------
 test_ac3_step5_substeps() {
-  echo "AC3: CLAUDE.md.template contains STEP 5a, 5b, 5c, 5d references"
+  echo "AC3: CLAUDE.md.template contains RED, GREEN, VERIFY, REFINE references"
   local all_found=true
-  for sub in 5a 5b 5c 5d; do
-    if ! grep -q "STEP $sub" "$TEMPLATE" 2>/dev/null; then
+  for phase in RED GREEN VERIFY REFINE; do
+    if ! grep -q "$phase" "$TEMPLATE" 2>/dev/null; then
       all_found=false
       break
     fi
   done
   if $all_found; then
-    pass "All STEP 5a/5b/5c/5d references found"
+    pass "All RED/GREEN/VERIFY/REFINE references found"
   else
-    fail "Missing one or more STEP 5a/5b/5c/5d references"
+    fail "Missing one or more RED/GREEN/VERIFY/REFINE references"
   fi
 }
 
-# ---------- AC 4: Flow Control Table includes 5a->5b->5c->5d transitions ----------
+# ---------- AC 4: Flow Control Table includes RED->GREEN->VERIFY->REFINE transitions ----------
 test_ac4_flow_control_transitions() {
-  echo "AC4: Flow Control Table in CLAUDE.md.template includes 5a->5b->5c->5d transitions"
-  # Check for flow control rows mentioning 5a, 5b, 5c, 5d
+  echo "AC4: Flow Control Table in CLAUDE.md.template includes RED->GREEN->VERIFY->REFINE transitions"
+  # Check for flow control rows mentioning RED, GREEN, VERIFY, REFINE
   local count
-  count=$(grep -cE '^\|.*STEP 5[abcd]' "$TEMPLATE" 2>/dev/null || true)
+  count=$(grep -cE '^\|.*(RED|GREEN|VERIFY|REFINE)' "$TEMPLATE" 2>/dev/null || true)
   count=${count:-0}
   # Ensure count is a single number
   count=$(echo "$count" | tail -1)
   if [ "$count" -ge 4 ]; then
-    pass "Flow control table has 5a/5b/5c/5d transitions"
+    pass "Flow control table has RED/GREEN/VERIFY/REFINE transitions"
   else
-    fail "Flow control table missing 5a/5b/5c/5d transitions (found $count rows)"
+    fail "Flow control table missing RED/GREEN/VERIFY/REFINE transitions (found $count rows)"
   fi
 }
 
-# ---------- AC 5: STEP 5a requires Red confirmation ----------
+# ---------- AC 5: RED phase requires Red confirmation ----------
 test_ac5_red_confirmation() {
-  echo "AC5: STEP 5a section requires Red confirmation (tests must FAIL)"
+  echo "AC5: RED section requires Red confirmation (tests must FAIL)"
   if grep -qi 'red.*confirm\|must.*fail\|all.*fail' "$TEMPLATE" 2>/dev/null &&
-     grep -q '5a' "$TEMPLATE" 2>/dev/null; then
-    # More specific: check that Red confirmation appears in context of 5a
-    # Extract section around 5a and check for Red/FAIL
-    if sed -n '/STEP 5a/,/STEP 5[bcd]/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'red|must.*fail|all.*fail'; then
-      pass "STEP 5a requires Red confirmation"
+     grep -q 'RED' "$TEMPLATE" 2>/dev/null; then
+    # More specific: check that Red confirmation appears in context of RED
+    # Extract section around RED and check for Red/FAIL
+    if sed -n '/^###* RED/,/^###* GREEN/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'red|must.*fail|all.*fail'; then
+      pass "RED phase requires Red confirmation"
     else
-      fail "STEP 5a does not mention Red confirmation"
+      fail "RED phase does not mention Red confirmation"
     fi
   else
-    fail "STEP 5a section with Red confirmation not found"
+    fail "RED section with Red confirmation not found"
   fi
 }
 
-# ---------- AC 6: STEP 5b states minimum implementation principle ----------
+# ---------- AC 6: GREEN phase states minimum implementation principle ----------
 test_ac6_minimum_implementation() {
-  echo "AC6: STEP 5b states minimum implementation principle"
-  if sed -n '/STEP 5b/,/STEP 5[cd]/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'minimum.*code|minimum.*implementation|not.*implement.*beyond.*test|do not implement.*not covered'; then
-    pass "STEP 5b states minimum implementation principle"
+  echo "AC6: GREEN section states minimum implementation principle"
+  if sed -n '/^###* GREEN/,/^###* VERIFY/p' "$TEMPLATE" 2>/dev/null | grep -qiE 'minimum.*code|minimum.*implementation|not.*implement.*beyond.*test|do not implement.*not covered'; then
+    pass "GREEN phase states minimum implementation principle"
   else
-    fail "STEP 5b minimum implementation principle not found"
+    fail "GREEN phase minimum implementation principle not found"
   fi
 }
 
-# ---------- AC 7: STEP 5c includes 4 failure paths ----------
+# ---------- AC 7: VERIFY phase includes 4 failure paths ----------
 test_ac7_four_failure_paths() {
-  echo "AC7: STEP 5c includes 4 failure paths (test issue, impl issue, both, deadlock)"
+  echo "AC7: VERIFY section includes 4 failure paths (test issue, impl issue, both, deadlock)"
   local section
-  section=$(sed -n '/STEP 5c/,/STEP 5d/p' "$TEMPLATE" 2>/dev/null)
+  section=$(sed -n '/^###* VERIFY/,/^###* REFINE/p' "$TEMPLATE" 2>/dev/null)
   if [ -z "$section" ]; then
-    fail "STEP 5c section not found"
+    fail "VERIFY section not found"
     return
   fi
   local paths_found=0
@@ -121,9 +121,9 @@ test_ac7_four_failure_paths() {
   echo "$section" | grep -qiE 'both' && paths_found=$((paths_found + 1))
   echo "$section" | grep -qiE 'deadlock' && paths_found=$((paths_found + 1))
   if [ "$paths_found" -ge 4 ]; then
-    pass "All 4 failure paths found in STEP 5c"
+    pass "All 4 failure paths found in VERIFY phase"
   else
-    fail "Only $paths_found of 4 failure paths found in STEP 5c"
+    fail "Only $paths_found of 4 failure paths found in VERIFY phase"
   fi
 }
 
@@ -131,9 +131,9 @@ test_ac7_four_failure_paths() {
 test_ac8_deadlock_fresh_eval() {
   echo "AC8: Deadlock path mentions fresh Evaluation AI"
   local section
-  section=$(sed -n '/STEP 5c/,/STEP 5d/p' "$TEMPLATE" 2>/dev/null)
+  section=$(sed -n '/^###* VERIFY/,/^###* REFINE/p' "$TEMPLATE" 2>/dev/null)
   if [ -z "$section" ]; then
-    fail "STEP 5c section not found for deadlock check"
+    fail "VERIFY section not found for deadlock check"
     return
   fi
   if echo "$section" | grep -qiE 'deadlock.*evaluation.*ai|evaluation.*ai.*arbitrat'; then
@@ -143,23 +143,23 @@ test_ac8_deadlock_fresh_eval() {
   fi
 }
 
-# ---------- AC 9: 5b<->5c round-trip limit: max 3 cycles ----------
+# ---------- AC 9: GREEN<->VERIFY round-trip limit: max 3 cycles ----------
 test_ac9_roundtrip_limit() {
-  echo "AC9: 5b<->5c round-trip limit: max 3 cycles documented"
-  if grep -qE '5b.*5c.*3|max.*3.*cycle|3.*round.?trip' "$TEMPLATE" 2>/dev/null; then
-    pass "5b<->5c max 3 cycle limit documented"
+  echo "AC9: GREEN<->VERIFY round-trip limit: max 3 cycles documented"
+  if grep -qE 'GREEN.*VERIFY.*3|VERIFY.*GREEN.*3|max.*3.*cycle|3.*round.?trip' "$TEMPLATE" 2>/dev/null; then
+    pass "GREEN<->VERIFY max 3 cycle limit documented"
   else
-    fail "5b<->5c max 3 cycle limit not found"
+    fail "GREEN<->VERIFY max 3 cycle limit not found"
   fi
 }
 
-# ---------- AC 10: STEP 5d includes refactor + Green re-confirmation + max 2 ----------
+# ---------- AC 10: REFINE phase includes refactor + Green re-confirmation + max 2 ----------
 test_ac10_refactor_green() {
-  echo "AC10: STEP 5d includes refactor with Green re-confirmation, max 2 attempts"
+  echo "AC10: REFINE section includes refactor with Green re-confirmation, max 2 attempts"
   local section
-  section=$(sed -n '/STEP 5d/,/STEP [67]/p' "$TEMPLATE" 2>/dev/null)
+  section=$(sed -n '/^###* REFINE/,/^###* GATE:QUALITY\|^###* REVISION\|^###* SHIP\|^###* LAND\|^## /p' "$TEMPLATE" 2>/dev/null)
   if [ -z "$section" ]; then
-    fail "STEP 5d section not found"
+    fail "REFINE section not found"
     return
   fi
   local checks=0
@@ -167,36 +167,36 @@ test_ac10_refactor_green() {
   echo "$section" | grep -qiE 'green|tests.*pass|re-run.*test' && checks=$((checks + 1))
   echo "$section" | grep -qiE 'max.*2|2.*attempt' && checks=$((checks + 1))
   if [ "$checks" -ge 3 ]; then
-    pass "STEP 5d has refactor, Green re-confirmation, max 2 attempts"
+    pass "REFINE phase has refactor, Green re-confirmation, max 2 attempts"
   else
-    fail "STEP 5d missing elements ($checks of 3 found)"
+    fail "REFINE phase missing elements ($checks of 3 found)"
   fi
 }
 
-# ---------- AC 11: autoflow-guide.md contains STEP 5a/5b/5c/5d subsections ----------
+# ---------- AC 11: autoflow-guide.md contains RED/GREEN/VERIFY/REFINE subsections ----------
 test_ac11_guide_substeps() {
-  echo "AC11: autoflow-guide.md contains STEP 5a/5b/5c/5d subsections"
+  echo "AC11: autoflow-guide.md contains RED/GREEN/VERIFY/REFINE subsections"
   local all_found=true
-  for sub in 5a 5b 5c 5d; do
-    if ! grep -qE '#+.*STEP '$sub'|#+.*5'${sub: -1} "$GUIDE" 2>/dev/null; then
+  for phase in RED GREEN VERIFY REFINE; do
+    if ! grep -qE '#+.*'"$phase" "$GUIDE" 2>/dev/null; then
       all_found=false
       break
     fi
   done
   if $all_found; then
-    pass "autoflow-guide.md has STEP 5a/5b/5c/5d subsections"
+    pass "autoflow-guide.md has RED/GREEN/VERIFY/REFINE subsections"
   else
-    fail "autoflow-guide.md missing STEP 5a/5b/5c/5d subsections"
+    fail "autoflow-guide.md missing RED/GREEN/VERIFY/REFINE subsections"
   fi
 }
 
-# ---------- AC 12: autoflow-guide.md regression rules include 5b<->5c cycle limits ----------
+# ---------- AC 12: autoflow-guide.md regression rules include GREEN<->VERIFY cycle limits ----------
 test_ac12_guide_regression() {
-  echo "AC12: autoflow-guide.md regression rules include 5b<->5c cycle limits"
-  if grep -qE '5b.*5c|5c.*5b' "$GUIDE" 2>/dev/null; then
-    pass "autoflow-guide.md regression rules include 5b<->5c cycle limits"
+  echo "AC12: autoflow-guide.md regression rules include GREEN<->VERIFY cycle limits"
+  if grep -qE 'GREEN.*VERIFY|VERIFY.*GREEN' "$GUIDE" 2>/dev/null; then
+    pass "autoflow-guide.md regression rules include GREEN<->VERIFY cycle limits"
   else
-    fail "autoflow-guide.md missing 5b<->5c cycle limits in regression rules"
+    fail "autoflow-guide.md missing GREEN<->VERIFY cycle limits in regression rules"
   fi
 }
 
@@ -220,25 +220,25 @@ test_ac14_no_5_7() {
   fi
 }
 
-# ---------- AC 15: evaluation-system.md references "STEP 5c" ----------
+# ---------- AC 15: evaluation-system.md references "VERIFY" ----------
 test_ac15_eval_step5c() {
-  echo "AC15: evaluation-system.md references STEP 5c (not flat STEP 5)"
-  if grep -q 'STEP 5c' "$EVAL_SYSTEM" 2>/dev/null; then
-    pass "evaluation-system.md references STEP 5c"
+  echo "AC15: evaluation-system.md references VERIFY (not generic TDD cycle)"
+  if grep -q 'VERIFY' "$EVAL_SYSTEM" 2>/dev/null; then
+    pass "evaluation-system.md references VERIFY"
   else
-    fail "evaluation-system.md does not reference STEP 5c"
+    fail "evaluation-system.md does not reference VERIFY"
   fi
 }
 
-# ---------- AC 16: README.md lifecycle table shows updated STEP 3/4/5 names ----------
+# ---------- AC 16: README.md lifecycle table shows updated GATE:PLAN/DISPATCH/RED names ----------
 test_ac16_readme_lifecycle() {
-  echo "AC16: README.md lifecycle table shows updated STEP 3/4/5 names"
+  echo "AC16: README.md lifecycle table shows updated GATE:PLAN/DISPATCH/RED names"
   local checks=0
-  grep -qE 'STEP 3.*Plan Evaluation' "$README" 2>/dev/null && checks=$((checks + 1))
-  grep -qE 'STEP 4.*Task Assignment' "$README" 2>/dev/null && checks=$((checks + 1))
-  grep -qE 'STEP 5a' "$README" 2>/dev/null && checks=$((checks + 1))
+  grep -qE 'GATE:PLAN.*Plan Evaluation' "$README" 2>/dev/null && checks=$((checks + 1))
+  grep -qE 'DISPATCH.*Task Assignment' "$README" 2>/dev/null && checks=$((checks + 1))
+  grep -qE '\bRED\b' "$README" 2>/dev/null && checks=$((checks + 1))
   if [ "$checks" -ge 3 ]; then
-    pass "README.md lifecycle table updated for STEP 3/4/5"
+    pass "README.md lifecycle table updated for GATE:PLAN/DISPATCH/RED"
   else
     fail "README.md lifecycle table not updated ($checks of 3 checks passed)"
   fi
@@ -247,7 +247,7 @@ test_ac16_readme_lifecycle() {
 # ---------- AC 17: Pure documentation changes bypass guidance ----------
 test_ac17_pure_docs_bypass() {
   echo "AC17: Pure documentation changes bypass guidance exists in CLAUDE.md.template"
-  if grep -qiE 'pure.*doc.*change|pure.*prose.*change|skip.*tdd|skip.*step.*5|bypass.*test' "$TEMPLATE" 2>/dev/null; then
+  if grep -qiE 'pure.*doc.*change|pure.*prose.*change|skip.*tdd|skip.*red\b|bypass.*test' "$TEMPLATE" 2>/dev/null; then
     pass "Pure documentation changes bypass guidance found"
   else
     fail "Pure documentation changes bypass guidance not found"

--- a/tests/test-tdd-cycle-restoration.sh
+++ b/tests/test-tdd-cycle-restoration.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Test: TDD Cycle Restoration (Issue #4)
-# Verifies RED/GREEN/VERIFY/REFINE sub-steps are present in template files.
+# Verifies RED/GREEN/VERIFY/REFINE sub-phases are present in template files.
 # All tests should FAIL (Red) before implementation.
 
 set -euo pipefail

--- a/tests/test_issue_18_sync.sh
+++ b/tests/test_issue_18_sync.sh
@@ -26,20 +26,20 @@ echo "===== Issue #18 Sync Tests ====="
 echo ""
 
 # --------------------------------------------------------------------------
-# AC1: CLAUDE.md.template STEP 5d has [MUST] marker for 5d-2 mandatory re-run
+# AC1: CLAUDE.md.template REFINE has [MUST] marker for mandatory re-run
 #      AND "DO NOT SKIP" text
 # --------------------------------------------------------------------------
-check "AC1: template STEP 5d has [MUST] marker for mandatory re-run" \
-  "grep -q '\[MUST\]' '$CLAUDE_TEMPLATE' && grep -A5 '5d-2' '$CLAUDE_TEMPLATE' | grep -q '\[MUST\]'"
+check "AC1: template REFINE has [MUST] marker for mandatory re-run" \
+  "grep -q '\[MUST\]' '$CLAUDE_TEMPLATE' && grep -A5 'REFINE-2\|refine-2' '$CLAUDE_TEMPLATE' | grep -q '\[MUST\]'"
 
-check "AC1b: template STEP 5d has DO NOT SKIP text" \
+check "AC1b: template REFINE has DO NOT SKIP text" \
   "grep -q 'DO NOT SKIP' '$CLAUDE_TEMPLATE'"
 
 # --------------------------------------------------------------------------
-# AC2: CLAUDE.md.template STEP 5d has no-refactoring path
+# AC2: CLAUDE.md.template REFINE has no-refactoring path
 #      (e.g., "No -> document reason" or "no refactoring needed")
 # --------------------------------------------------------------------------
-check "AC2: template STEP 5d has no-refactoring path" \
+check "AC2: template REFINE has no-refactoring path" \
   "grep -i -q 'no.*document reason\|no refactoring needed\|No.*→.*document\|Refactoring needed' '$CLAUDE_TEMPLATE'"
 
 # --------------------------------------------------------------------------
@@ -68,20 +68,20 @@ check "AC4c: template Eval AI Prompt Rules has >= 1 DENY rule" \
   "grep -A10 'Evaluation AI Prompt Rules' '$CLAUDE_TEMPLATE' | grep -q '\[DENY\]'"
 
 # --------------------------------------------------------------------------
-# AC5: CLAUDE.md.template Flow Control AUTO-FAIL line routes to STEP 4
+# AC5: CLAUDE.md.template Flow Control AUTO-FAIL line routes to DISPATCH
 # --------------------------------------------------------------------------
-check "AC5: template AUTO-FAIL routes to STEP 4 (not STEP 3)" \
-  "grep -i 'auto-fail\|AUTO-FAIL' '$CLAUDE_TEMPLATE' | grep -q 'STEP 4'"
+check "AC5: template AUTO-FAIL routes to DISPATCH (not GATE:PLAN)" \
+  "grep -i 'auto-fail\|AUTO-FAIL' '$CLAUDE_TEMPLATE' | grep -q 'DISPATCH'"
 
 # --------------------------------------------------------------------------
-# AC6: docs/autoflow-guide.md STEP 5d has [MUST] marker for mandatory re-run
+# AC6: docs/autoflow-guide.md REFINE has [MUST] marker for mandatory re-run
 #      AND "no refactoring" path language
 # --------------------------------------------------------------------------
-check "AC6a: autoflow-guide STEP 5d has [MUST] marker" \
-  "awk '/^## STEP 5d/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -q '\[MUST\]'"
+check "AC6a: autoflow-guide REFINE has [MUST] marker" \
+  "awk '/^## REFINE/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -q '\[MUST\]'"
 
-check "AC6b: autoflow-guide STEP 5d has no-refactoring path" \
-  "awk '/^## STEP 5d/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -qi 'no.*refactor\|Refactoring needed'"
+check "AC6b: autoflow-guide REFINE has no-refactoring path" \
+  "awk '/^## REFINE/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -qi 'no.*refactor\|Refactoring needed'"
 
 # --------------------------------------------------------------------------
 # AC7: docs/autoflow-guide.md has orchestrator boundaries section
@@ -90,14 +90,14 @@ check "AC7: autoflow-guide has Orchestrator Boundaries section" \
   "grep -q 'Orchestrator Boundaries' '$AUTOFLOW_GUIDE'"
 
 # --------------------------------------------------------------------------
-# AC8: docs/autoflow-guide.md AUTO-FAIL routes to STEP 4 in STEP 6 section
+# AC8: docs/autoflow-guide.md AUTO-FAIL routes to DISPATCH in GATE:QUALITY section
 #      AND in Regression Rules table
 # --------------------------------------------------------------------------
-check "AC8a: autoflow-guide STEP 6 AUTO-FAIL routes to STEP 4" \
-  "awk '/## STEP 6/,/## STEP 7/{print}' '$AUTOFLOW_GUIDE' | grep -i 'auto-fail\|security.*<=.*3' | grep -q 'STEP 4'"
+check "AC8a: autoflow-guide GATE:QUALITY AUTO-FAIL routes to DISPATCH" \
+  "awk '/## GATE:QUALITY/,/## REVISION/{print}' '$AUTOFLOW_GUIDE' | grep -i 'auto-fail\|security.*<=.*3' | grep -q 'DISPATCH'"
 
-check "AC8b: autoflow-guide Regression Rules AUTO-FAIL routes to STEP 4" \
-  "awk '/^## Regression Rules/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -i 'security.*<=.*3' | grep -q 'STEP 4'"
+check "AC8b: autoflow-guide Regression Rules AUTO-FAIL routes to DISPATCH" \
+  "awk '/^## Regression Rules/,/^---$/{print}' '$AUTOFLOW_GUIDE' | grep -i 'security.*<=.*3' | grep -q 'DISPATCH'"
 
 # --------------------------------------------------------------------------
 # AC9: docs/autoflow-guide.md has Evaluation AI Prompt Rules
@@ -117,10 +117,10 @@ check "AC10b: autoflow-guide evaluation categories use Security (not Consistency
   "awk '/Scoring Categories/,/### PASS/{print}' '$AUTOFLOW_GUIDE' | grep -q 'Security'"
 
 # --------------------------------------------------------------------------
-# AC11: docs/evaluation-system.md AUTO-FAIL routes to STEP 4
+# AC11: docs/evaluation-system.md AUTO-FAIL routes to DISPATCH
 # --------------------------------------------------------------------------
-check "AC11: evaluation-system.md AUTO-FAIL routes to STEP 4 (not STEP 3)" \
-  "grep -i 'auto-fail\|Security.*<=.*3' '$EVAL_SYSTEM' | grep -q 'STEP 4'"
+check "AC11: evaluation-system.md AUTO-FAIL routes to DISPATCH (not GATE:PLAN)" \
+  "grep -i 'auto-fail\|Security.*<=.*3' '$EVAL_SYSTEM' | grep -q 'DISPATCH'"
 
 # --------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

- STEP 0–9 숫자 기반 네이밍을 의미 전달이 명확한 phase 이름으로 변경
- `GATE:` 접두어로 평가 게이트를 즉시 구분 가능
- 16개 파일, ~550줄 변경, 97/97 테스트 통과

## Phase Naming Map

| Before | After | Purpose |
|--------|-------|---------|
| STEP 0 | PREFLIGHT | Git clean, branch creation |
| STEP 1 | DIAGNOSE | 3-Phase independent analysis |
| STEP 1.5 | GATE:HYPOTHESIS | Hypothesis evaluation gate |
| STEP 2 | ARCHITECT | Plan synthesis |
| STEP 3 | GATE:PLAN | Plan evaluation gate |
| STEP 4 | DISPATCH | Task assignment |
| STEP 5a | RED | Test writing (all must fail) |
| STEP 5b | GREEN | Minimum implementation |
| STEP 5c | VERIFY | Green verification |
| STEP 5d | REFINE | Refactor + re-confirm |
| STEP 6 | GATE:QUALITY | Final quality gate |
| STEP 7 | REVISION | Fix evaluation feedback |
| STEP 8 | SHIP | PR creation |
| STEP 9 | LAND | Merge + cleanup |

## Test plan

- [x] test-check-autoflow-gate.sh — 42/42 pass
- [x] test-delegation-gate.sh — 23/23 pass
- [x] test-step0-restoration.sh — 15/15 pass
- [x] test-tdd-cycle-restoration.sh — 17/17 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)