### PR TITLE
feat(#27): introduce phase-transition three-party responsibility split

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ All other files require delegation to teammates:
 
 **No exceptions.** The previous "documentation bulk updates" exception was removed because it allowed the orchestrator to bypass delegation for nearly any file. If a file is not in the orchestrator's list above, it must go through a teammate — regardless of how simple the change appears.
 
+**The Orchestrator does not interpret evidence content.** When a Teammate emits a `transition-request`, the Orchestrator's only action is to invoke the `phase-set` helper passing the `evidence` field verbatim. Reading, summarizing, or judging the evidence is out of scope — that judgment belongs to the Hook (mechanical prerequisite checks) or to a fresh Evaluation AI (gate scoring).
+
 ### Communication — Agent Teams
 
 ```
@@ -88,6 +90,29 @@ Orchestrator → Agent (fresh, no team)               : spawn Evaluation AI (ind
 ```
 
 All teammates work on the **same repository** (single repo — no submodule navigation needed).
+
+### Phase Transition Protocol
+
+Phase transitions follow a three-party split — see [docs/design-rationale.md > Decision 8](docs/design-rationale.md#decision-8-phase-transitions-use-a-three-party-split-teammate--orchestrator--hook).
+
+| Party | Responsibility at a phase transition |
+|-------|--------------------------------------|
+| Teammate | Produces the artifact required by the current phase and emits a `transition-request` to the Orchestrator citing the next phase and evidence. |
+| Orchestrator | Mechanical pass-through — invokes the `phase-set` helper with the `evidence` field passed verbatim. Does not interpret evidence content. |
+| Hook | Mechanical prerequisite verification (artifacts exist, GATE PASS where applicable, role marker correct); allows or blocks the transition. |
+
+A Teammate requests a transition by sending the Orchestrator a message in this canonical format:
+
+```
+@orchestrator transition-request
+from: <CURRENT_PHASE>
+to: <NEXT_PHASE>
+evidence: <artifact path or short factual statement>
+```
+
+- **[MUST]** A `transition-request` must address the Orchestrator. Sibling-to-sibling transition messages between Teammates are forbidden.
+- **[MUST]** The Orchestrator's response is to invoke the `phase-set` helper (see Item 2 / #28) with the `evidence` field passed verbatim — no reading, summarizing, or judging of the evidence content.
+- The `phase-set` helper is the mechanical pass-through that will be introduced by Item 2 (#28); until then, Orchestrators emulate it by writing the phase file directly while preserving the no-interpretation contract.
 
 ### Phase Definitions
 

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -160,6 +160,8 @@ All other files require delegation to teammates:
 
 **No exceptions.** The previous "documentation bulk updates" exception was removed because it allowed the orchestrator to bypass delegation for nearly any file. If a file is not in the orchestrator's list above, it must go through a teammate — regardless of how simple the change appears.
 
+**The Orchestrator does not interpret evidence content.** When a Teammate emits a `transition-request`, the Orchestrator's only action is to invoke the `phase-set` helper passing the `evidence` field verbatim. Reading, summarizing, or judging the evidence is out of scope — that judgment belongs to the Hook (mechanical prerequisite checks) or to a fresh Evaluation AI (gate scoring).
+
 ### Evaluation AI Prompt Rules
 
 1. **[MUST]** Include: evaluation type, `CLAUDE.md > [section]` reference, target file paths
@@ -179,6 +181,29 @@ Test AI → Orchestrator: "All tests pass"
 Orchestrator → Evaluation AI: "Evaluate feature X implementation"
 Evaluation AI → Orchestrator: "Score: 8/10 — PASS"
 ```
+
+### Phase Transition Protocol
+
+Phase transitions follow a three-party split — see [docs/design-rationale.md > Decision 8](docs/design-rationale.md#decision-8-phase-transitions-use-a-three-party-split-teammate--orchestrator--hook).
+
+| Party | Responsibility at a phase transition |
+|-------|--------------------------------------|
+| Teammate | Produces the artifact required by the current phase and emits a `transition-request` to the Orchestrator citing the next phase and evidence. |
+| Orchestrator | Mechanical pass-through — invokes the `phase-set` helper with the `evidence` field passed verbatim. Does not interpret evidence content. |
+| Hook | Mechanical prerequisite verification (artifacts exist, GATE PASS where applicable, role marker correct); allows or blocks the transition. |
+
+A Teammate requests a transition by sending the Orchestrator a message in this canonical format:
+
+```
+@orchestrator transition-request
+from: <CURRENT_PHASE>
+to: <NEXT_PHASE>
+evidence: <artifact path or short factual statement>
+```
+
+- **[MUST]** A `transition-request` must address the Orchestrator. Sibling-to-sibling transition messages between Teammates are forbidden.
+- **[MUST]** The Orchestrator's response is to invoke the `phase-set` helper (see Item 2 / #28) with the `evidence` field passed verbatim — no reading, summarizing, or judging of the evidence content.
+- The `phase-set` helper is the mechanical pass-through that will be introduced by Item 2 (#28); until then, Orchestrators emulate it by writing the phase file directly while preserving the no-interpretation contract.
 
 ---
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -149,6 +149,31 @@ When introducing any new loop structure to this system, it must have an explicit
 
 ---
 
+### Decision 8: Phase Transitions Use a Three-Party Split (Teammate / Orchestrator / Hook)
+
+**What it does**
+
+Phase transitions in Auto-Flow are split across three parties so that no single party owns both the content judgment and the state mutation. Each party performs exactly one mechanical role at a transition.
+
+| Party | Responsibility at a phase transition |
+|-------|--------------------------------------|
+| Teammate | Produces the artifact required by the current phase and emits a `transition-request` message addressed to the Orchestrator, naming the next phase and citing the evidence path. |
+| Orchestrator | Acts as a mechanical pass-through — invokes the `phase-set` helper with the `evidence` field passed verbatim. Does not read, summarize, or judge the evidence content. |
+| Hook | Performs mechanical prerequisite verification (required artifacts exist, GATE evaluation PASS where applicable, role marker correct) and either allows or blocks the transition. |
+
+**Why it works this way**
+
+Bias isolation. Phase progression mixes two different concerns: *content correctness* (is the artifact good?) and *state mutation* (advance the phase pointer). If the same party owns both, the party that judges content also chooses whether to advance — and self-reinforcement bias creeps back in. The three-party split ensures the Teammate provides evidence but cannot self-promote, the Orchestrator advances state but cannot interpret content, and the Hook checks mechanical prerequisites without authoring or judging artifacts. Any party doing more than its row would force content judgment back into the loop.
+
+**Rejected alternatives**
+
+- **Model 1: Teammate-autonomous.** The teammate writes its own phase file at completion. Rejected because it produces a phase-file blind spot — neither the Orchestrator nor the Hook owns the update, so a teammate can advance the system into a phase it did not earn, and there is no mechanical record of who authorized the transition.
+- **Model 2: Orchestrator-gated.** The Orchestrator reads the evidence and decides whether the transition is justified. Rejected because gating forces the Orchestrator to interpret evidence content, which violates the Orchestrator-does-not-judge-content invariant established by the prompt rules and Decision 1. Once the Orchestrator interprets evidence in one place, the same justification ("just a quick check") leaks into evaluation prompts and DIAGNOSE inputs.
+
+The mechanical entry point invoked by the Orchestrator is the `phase-set` helper. The `phase-set` helper itself is tracked separately as Item 2 (#28) and will be introduced by that issue; this decision specifies the contract it must satisfy (mechanical pass-through, evidence verbatim, no content interpretation).
+
+---
+
 ## Evaluation System Design Intent
 
 ### Why Scoring Criteria Are Not Fixed
@@ -178,6 +203,7 @@ The following may look like "better approaches" but undermine core principles:
 | Allow phase-skipping judgment | "This one is simple" is itself a biased judgment |
 | Let the pipeline modify its own criteria | Judgment tracing impossible → trust chain collapse |
 | Design loops without termination conditions | No maximum retry → infinite loop risk → system hangs |
+| Let a Teammate send a phase-transition request to another Teammate | Bypasses the Orchestrator — no party authorizes peer transitions, breaks the three-party split |
 
 ---
 

--- a/tests/test-issue-27-phase-transition-protocol.sh
+++ b/tests/test-issue-27-phase-transition-protocol.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Test Suite: Phase-Transition Responsibility Model (Issue #27)
+# Encodes the 8 acceptance criteria from .autoflow-state/27/plan.md section 4.
+# All grep/diff checks MUST FAIL (Red) against the unmodified docs.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+CLAUDE_TEMPLATE="$REPO_ROOT/CLAUDE.md.template"
+DESIGN_RATIONALE="$REPO_ROOT/docs/design-rationale.md"
+
+FAILURES=0
+TOTAL=0
+
+pass() {
+  TOTAL=$((TOTAL + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  TOTAL=$((TOTAL + 1))
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL: $1"
+}
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$2" >/dev/null 2>&1; then
+    echo "PASS: $1"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+  fi
+}
+
+echo "============================================================"
+echo "Issue #27: Phase-Transition Responsibility Model Tests"
+echo "============================================================"
+echo ""
+
+# ============================================================
+# AC1: Three-party split documented in design-rationale.md
+# ============================================================
+echo "--- AC1: design-rationale.md documents three-party split ---"
+
+check "1a. design-rationale.md mentions Teammate/Orchestrator/Hook split or 'three-party'" \
+  "grep -E 'Teammate.*Orchestrator.*Hook|three-party' '$DESIGN_RATIONALE'"
+
+echo ""
+
+# ============================================================
+# AC2: Rejected alternatives named with reasons
+# ============================================================
+echo "--- AC2: Rejected alternatives named with stated reasons ---"
+
+check "2a. design-rationale.md names 'Teammate-autonomous' model" \
+  "grep -E 'Teammate-autonomous' '$DESIGN_RATIONALE'"
+
+check "2b. design-rationale.md names 'Orchestrator-gated' model" \
+  "grep -E 'Orchestrator-gated' '$DESIGN_RATIONALE'"
+
+# Each named model must have a stated reason within 10 lines after the name
+# (looking for 'blind spot' near Teammate-autonomous, 'interpret' near Orchestrator-gated).
+check "2c. 'Teammate-autonomous' has rejection reason ('blind spot' within 10 lines)" \
+  "grep -A10 'Teammate-autonomous' '$DESIGN_RATIONALE' | grep -qiE 'blind spot|blind-spot'"
+
+check "2d. 'Orchestrator-gated' has rejection reason ('interpret' within 10 lines)" \
+  "grep -A10 'Orchestrator-gated' '$DESIGN_RATIONALE' | grep -qi 'interpret'"
+
+echo ""
+
+# ============================================================
+# AC3: Canonical transition-request format in CLAUDE.md and template
+# Token sequence: @orchestrator transition-request, then from:, to:, evidence:
+# Verifiable with grep -A4 -- the captured 5 lines must contain the
+# fields in order.
+# ============================================================
+echo "--- AC3: Canonical transition-request format present in both files ---"
+
+check_transition_block() {
+  local label="$1" file="$2"
+  local block from_line to_line ev_line
+  TOTAL=$((TOTAL + 1))
+
+  if ! grep -q "@orchestrator transition-request" "$file" 2>/dev/null; then
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $label (no '@orchestrator transition-request' header)"
+    return
+  fi
+
+  # Capture header line + next 4 lines (5 lines total)
+  block=$(grep -A4 "@orchestrator transition-request" "$file" | head -n 5)
+
+  # Find which line numbers (1..5 in the captured block) contain each field.
+  from_line=$(echo "$block" | grep -n '^.*from:' | head -n 1 | cut -d: -f1 || true)
+  to_line=$(echo "$block" | grep -n '^.*to:' | head -n 1 | cut -d: -f1 || true)
+  ev_line=$(echo "$block" | grep -n '^.*evidence:' | head -n 1 | cut -d: -f1 || true)
+
+  if [ -z "$from_line" ] || [ -z "$to_line" ] || [ -z "$ev_line" ]; then
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $label (missing one of from:/to:/evidence: in 5-line block)"
+    return
+  fi
+
+  if [ "$from_line" -lt "$to_line" ] && [ "$to_line" -lt "$ev_line" ]; then
+    echo "PASS: $label"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $label (fields not in from:->to:->evidence: order; got lines $from_line/$to_line/$ev_line)"
+  fi
+}
+
+check_transition_block "3a. CLAUDE.md has 5-line transition-request block (from->to->evidence)" "$CLAUDE_MD"
+check_transition_block "3b. CLAUDE.md.template has 5-line transition-request block (from->to->evidence)" "$CLAUDE_TEMPLATE"
+
+echo ""
+
+# ============================================================
+# AC4: 'does not interpret evidence' phrase in CLAUDE.md
+# ============================================================
+echo "--- AC4: Orchestrator non-interpretation rule in CLAUDE.md ---"
+
+check "4a. CLAUDE.md contains 'does not interpret evidence'" \
+  "grep -q 'does not interpret evidence' '$CLAUDE_MD'"
+
+echo ""
+
+# ============================================================
+# AC5: Sibling-prohibition / address-the-Orchestrator rule
+# ============================================================
+echo "--- AC5: Sibling-to-sibling transitions explicitly prohibited ---"
+
+check "5a. CLAUDE.md has sibling-prohibition or 'must address the Orchestrator' wording" \
+  "grep -iE 'sibling.*forbidden|sibling-to-sibling.*prohibit|must address the Orchestrator' '$CLAUDE_MD'"
+
+echo ""
+
+# ============================================================
+# AC6: Canonical format block byte-identical between CLAUDE.md and template
+# ============================================================
+echo "--- AC6: Canonical format block byte-identical across CLAUDE.md and template ---"
+
+TOTAL=$((TOTAL + 1))
+if grep -q "@orchestrator transition-request" "$CLAUDE_MD" 2>/dev/null \
+   && grep -q "@orchestrator transition-request" "$CLAUDE_TEMPLATE" 2>/dev/null; then
+  CLAUDE_BLOCK=$(grep -A4 "@orchestrator transition-request" "$CLAUDE_MD" | head -n 5)
+  TEMPLATE_BLOCK=$(grep -A4 "@orchestrator transition-request" "$CLAUDE_TEMPLATE" | head -n 5)
+  DIFF_OUTPUT=$(diff <(printf '%s\n' "$CLAUDE_BLOCK") <(printf '%s\n' "$TEMPLATE_BLOCK") || true)
+  if [ -z "$DIFF_OUTPUT" ]; then
+    echo "PASS: 6a. Canonical 5-line transition-request block is byte-identical in both files"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: 6a. Canonical transition-request block differs between CLAUDE.md and CLAUDE.md.template"
+  fi
+else
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL: 6a. Canonical transition-request block missing from one or both files"
+fi
+
+echo ""
+
+# ============================================================
+# AC7: phase-set helper forward-reference in CLAUDE.md AND design-rationale.md
+# ============================================================
+echo "--- AC7: phase-set helper forward-reference in both files ---"
+
+check "7a. CLAUDE.md mentions phase-set with forward-ref (#28 / Item 2 / will be introduced)" \
+  "grep -E 'phase-set.*(#28|Item 2|will be introduced)' '$CLAUDE_MD'"
+
+check "7b. design-rationale.md mentions phase-set with forward-ref (#28 / Item 2 / will be introduced)" \
+  "grep -E 'phase-set.*(#28|Item 2|will be introduced)' '$DESIGN_RATIONALE'"
+
+echo ""
+
+# ============================================================
+# AC8: git diff --name-only main..HEAD restricted to allowed paths
+# Lenient: only fail if a forbidden path is present (subset is fine).
+# Allowed prefixes/files:
+#   - CLAUDE.md
+#   - CLAUDE.md.template
+#   - docs/design-rationale.md
+#   - tests/test-issue-27-phase-transition-protocol.sh
+#   - .autoflow-state/27/...
+# ============================================================
+echo "--- AC8: Only allowed files modified vs main ---"
+
+TOTAL=$((TOTAL + 1))
+DIFF_FILES=$(git -C "$REPO_ROOT" diff --name-only main..HEAD 2>/dev/null || true)
+FORBIDDEN_FILES=""
+if [ -n "$DIFF_FILES" ]; then
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in
+      CLAUDE.md) ;;
+      CLAUDE.md.template) ;;
+      docs/design-rationale.md) ;;
+      tests/test-issue-27-phase-transition-protocol.sh) ;;
+      .autoflow-state/27/*) ;;
+      .autoflow-state/27) ;;
+      *) FORBIDDEN_FILES="$FORBIDDEN_FILES$f"$'\n' ;;
+    esac
+  done <<EOF
+$DIFF_FILES
+EOF
+fi
+
+if [ -z "$FORBIDDEN_FILES" ]; then
+  echo "PASS: 8a. git diff main..HEAD contains no forbidden paths"
+else
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL: 8a. git diff main..HEAD contains forbidden paths:"
+  printf '%s' "$FORBIDDEN_FILES" | sed 's/^/      /'
+fi
+
+echo ""
+
+# ============================================================
+# Manual checklist (criterion 6 semantic non-contradiction
+# and criterion 1 "exactly one responsibility row per party")
+# ============================================================
+echo "--- Manual checklist (human verification at GATE:QUALITY) ---"
+echo "  [ ] M1. design-rationale.md three-party section has exactly one"
+echo "         responsibility row per party (Teammate, Orchestrator, Hook)."
+echo "  [ ] M2. The three-party split, canonical format, and"
+echo "         non-interpretation rule do not semantically contradict each"
+echo "         other across CLAUDE.md, CLAUDE.md.template, and"
+echo "         docs/design-rationale.md."
+echo ""
+
+# ============================================================
+# Summary
+# ============================================================
+echo "============================================================"
+echo "RESULT: $FAILURES failures of $TOTAL checks"
+echo "============================================================"
+
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Implements Item 1 of #26 — establishes a three-party responsibility split (Teammate / Orchestrator / Hook) for phase transitions in Auto-Flow.

- **`docs/design-rationale.md`**: new Decision 8 with the responsibility table, bias-isolation rationale, and two named rejected models (Teammate-autonomous, Orchestrator-gated). Adds a sibling-prohibition row to "What Must NOT Be Done".
- **`CLAUDE.md`** and **`CLAUDE.md.template`**: append "Orchestrator does not interpret evidence content" to Orchestrator Boundaries; add a new "Phase Transition Protocol" section with the canonical `@orchestrator transition-request` block (byte-identical across both files), sibling-forbidden bullet, and forward reference to the `phase-set` helper that Item 2 (#28) will introduce.

## Test plan

- [x] `bash tests/test-issue-27-phase-transition-protocol.sh` — 13/13 grep/diff checks pass
- [x] M1 (manual): Decision 8 has exactly one responsibility row per party
- [x] M2 (manual): no semantic contradictions across the three updated files
- [x] GATE:HYPOTHESIS PASS (avg 8.33, Type 2 Documentation/Consistency)
- [x] GATE:PLAN PASS (avg 9.2)
- [x] GATE:QUALITY PASS (avg 9.2, Consistency 10)

Closes #27.
Sub-issue of #26.


---
_Generated by [Claude Code](https://claude.ai/code/session_0153Rc3VfniBewqb9NvJFYKy)_