### PR TITLE
feat(#29): evaluation JSON standard schema with role_marker enforcement

### DIFF
--- a/.claude/hooks/check-autoflow-gate.sh
+++ b/.claude/hooks/check-autoflow-gate.sh
@@ -65,6 +65,18 @@ END {
                 exit 2
               fi
               ;;
+            *.autoflow-state/*/evaluation.json|*.autoflow-state/*/evaluation/*.json)
+              if [ "$_autoflow_tool" = "Write" ]; then
+                # Payload embeds file content as escaped JSON string — \"role_marker\" confirms evaluator object.
+                _autoflow_role_marker_found="$(awk \
+                  '/\\"role_marker\\"[[:space:]]*:[[:space:]]*\\"[^\\"\\\\]/ { print "found"; exit }' \
+                  <<< "$_autoflow_payload")"
+                if [ -z "$_autoflow_role_marker_found" ]; then
+                  echo "[AutoFlow Gate] evaluation.json blocked: evaluator.role_marker is missing. Evaluation AI must emit the standard schema." >&2
+                  exit 2
+                fi
+              fi
+              ;;
           esac
           ;;
       esac

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ This project follows Auto-Flow with Agent Teams. Even though this is a single re
 2. **[MUST]** Do NOT copy evaluation criteria into the prompt — instruct the AI to read CLAUDE.md directly
 3. **[MUST]** Orchestrator-written portion must be 5 lines or fewer (excluding target file contents)
 4. **[DENY]** No opinions, interpretations, or leading phrases ("consider that ~", "note that ~", "this is ~ so")
+5. **[MUST]** Evaluation AI output MUST include `evaluator.role_marker` with the gate-specific value: `[role:eval-hypothesis]`, `[role:eval-plan]`, or `[role:eval-quality]`. The hook will block evaluation JSON writes that omit this field.
 
 ### Orchestrator Boundaries
 
@@ -448,22 +449,32 @@ When the change is purely prose (no scripts, no templates with placeholders):
 
 ### Evaluation Output Format
 
+> See `docs/evaluation-system.md` for the full schema. This is the abbreviated reference.
+
 ```json
 {
   "phase": "GATE:QUALITY",
   "issue": "#N",
-  "evaluator": "evaluation-ai",
+  "evaluator": {
+    "role_marker": "[role:eval-quality]",
+    "session_id": "<session-id>"
+  },
   "scores": {
     "correctness": { "score": 8, "reason": "..." },
     "quality": { "score": 7, "reason": "..." },
     "test_coverage": { "score": 7, "reason": "..." },
     "consistency": { "score": 9, "reason": "..." },
     "documentation": { "score": 8, "reason": "..." }
-  }
+  },
+  "average": 7.8,
+  "verdict": "PASS",
+  "blocking_issues": [],
+  "suggestions": ["..."],
+  "rationale": "..."
 }
 ```
 
-The Hook calculates pass/fail from raw `scores` — it does NOT trust AI's `pass` field.
+The Hook calculates pass/fail from raw `scores` — it does NOT trust AI's `verdict`, `pass`, or `average` fields.
 
 ---
 

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -439,17 +439,19 @@ When the change is purely prose (no scripts, no templates with placeholders):
 {
   "phase": "GATE:QUALITY",
   "issue": "#123",
-  "evaluator": "evaluation-ai",
-  "scores": {
-    "correctness": 8,
-    "code_quality": 7,
-    "test_coverage": 7,
-    "security": 8,
-    "performance": 7
+  "evaluator": {
+    "role_marker": "[role:eval-quality]",
+    "session_id": "<session-id>"
   },
-  "overall": 7.5,
-  "pass": true,
-  "comments": "Implementation meets requirements. Minor suggestion: ..."
+  "scores": {
+    "correctness": { "score": 8, "reason": "..." },
+    "quality": { "score": 7, "reason": "..." }
+  },
+  "average": 7.6,
+  "verdict": "PASS",
+  "blocking_issues": [],
+  "suggestions": ["..."],
+  "rationale": "..."
 }
 ```
 

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -108,14 +108,18 @@ overall:                   7.85  → FAIL (test_coverage 6 < minimum 7)
 
 ## Evaluation Output Format
 
+> This section is the **single source of truth** for the evaluation JSON schema. `CLAUDE.md.template` and `CLAUDE.md` reference this schema — keep them in sync.
+
 The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evaluation.json`:
 
 ```json
 {
   "phase": "GATE:QUALITY",
   "issue": "#123",
-  "evaluator": "evaluation-ai",
-  "timestamp": "2025-01-15T10:30:00Z",
+  "evaluator": {
+    "role_marker": "[role:eval-quality]",
+    "session_id": "<session-id>"
+  },
   "scores": {
     "correctness": { "score": 8, "reason": "All requirements met. Edge case for empty input handled correctly." },
     "quality": { "score": 7, "reason": "Clean implementation. Consider extracting the validation logic into a helper." },
@@ -123,11 +127,14 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
     "consistency": { "score": 9, "reason": "Aligned with design-rationale.md principles throughout." },
     "documentation": { "score": 7, "reason": "Docs updated. Internal links valid." }
   },
+  "average": 7.8,
+  "verdict": "PASS",
   "blocking_issues": [],
   "suggestions": [
     "Consider adding a test for the concurrent access scenario",
     "The validation helper extraction would improve readability"
-  ]
+  ],
+  "rationale": "Implementation meets all acceptance criteria. Minor refactoring suggestions are non-blocking."
 }
 ```
 
@@ -137,13 +144,19 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
 |-------|------|-------------|
 | `phase` | string | Always `"GATE:QUALITY"` for evaluation |
 | `issue` | string | Issue reference (e.g., "#123") |
-| `evaluator` | string | Agent identifier |
-| `timestamp` | string | ISO 8601 timestamp |
+| `evaluator` | object | Evaluation AI identity — must be an object, not a flat string |
+| `evaluator.role_marker` | string | Gate-specific role identifier — required, must be non-empty. Values: `[role:eval-hypothesis]`, `[role:eval-plan]`, `[role:eval-quality]` |
+| `evaluator.session_id` | string | Session identifier for traceability |
 | `scores` | object | Per-category scores — structured format with `score` and `reason` |
-| `blocking_issues` | array | Issues that must be fixed (empty if pass) |
-| `suggestions` | array | Non-blocking improvement ideas |
+| `average` | number | Weighted average score computed by the Evaluation AI |
+| `verdict` | string | `"PASS"` or `"FAIL"` — computed by the Evaluation AI (hook recalculates independently) |
+| `blocking_issues` | array | Issues that must be fixed before proceeding (empty array if no blockers) |
+| `suggestions` | array | Non-blocking improvement ideas for future consideration |
+| `rationale` | string | Overall narrative summary explaining the verdict |
 
-> **Note**: The hook does NOT read any AI-generated `pass` or `overall` fields. It calculates pass/fail independently from the raw `scores` values. Flat format (`"key": N`) is also supported for backward compatibility.
+> **Note**: The hook does NOT read any AI-generated `verdict`, `pass`, or `average` fields. It calculates pass/fail independently from the raw `scores` values. Flat format (`"key": N`) is also supported for backward compatibility.
+>
+> **Important**: The hook enforces that `evaluator.role_marker` is present and non-empty on every Write to an evaluation JSON file. A flat `"evaluator": "string"` will be blocked.
 
 ---
 

--- a/tests/test-hook-role-marker.sh
+++ b/tests/test-hook-role-marker.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: evaluator.role_marker PreToolUse validation (Issue #29)
+# =============================================================================
+# Validates that check-autoflow-gate.sh blocks Write to evaluation JSON files
+# when the content lacks evaluator.role_marker, and allows the write when
+# role_marker is present.
+#
+# Acceptance criteria tested:
+#   AC1: Hook blocks Write to *.autoflow-state/*/evaluation.json
+#        when evaluator.role_marker is absent → exit code 2
+#   AC2: Hook blocks Write to *.autoflow-state/*/evaluation/*.json
+#        when evaluator.role_marker is absent → exit code 2
+#   AC3: Hook allows Write to evaluation JSON when
+#        evaluator.role_marker is present and non-empty → exit code 0
+#   AC4: Hook allows Edit to evaluation JSON regardless of content → exit code 0
+#   AC5: Hook allows MultiEdit to evaluation JSON regardless of content → exit code 0
+#   AC6: Hook allows Write to non-evaluation JSON (e.g., plan.json)
+#        regardless of content → exit code 0
+#
+# All tests MUST FAIL (RED) until the hook feature is implemented.
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="${REPO_ROOT}/.claude/hooks/check-autoflow-gate.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+assert_exit_code() {
+  local expected="$1" actual="$2" desc="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (expected exit $expected, got $actual)")
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+  fi
+}
+
+assert_stderr_contains() {
+  local stderr_file="$1" pattern="$2" desc="$3"
+  if grep -q "$pattern" "$stderr_file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' not found in stderr)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+TEST_DIR=""
+
+setup_test_dir() {
+  TEST_DIR=$(mktemp -d)
+}
+
+cleanup_test_dir() {
+  if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+}
+
+# Build a PreToolUse Write payload for an evaluation JSON path with given content
+make_write_payload() {
+  local file_path="$1"
+  local content="$2"
+  # Escape double quotes in content for embedding in JSON string
+  local escaped_content
+  escaped_content=$(printf '%s' "$content" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+  printf '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"%s","content":"%s"}}' \
+    "$file_path" "$escaped_content"
+}
+
+# Build a PreToolUse Edit payload for an evaluation JSON path
+make_edit_payload() {
+  local file_path="$1"
+  printf '{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"%s","old_string":"old","new_string":"new"}}' \
+    "$file_path"
+}
+
+# Build a PreToolUse MultiEdit payload for an evaluation JSON path
+make_multiedit_payload() {
+  local file_path="$1"
+  printf '{"hook_event_name":"PreToolUse","tool_name":"MultiEdit","tool_input":{"file_path":"%s","edits":[]}}' \
+    "$file_path"
+}
+
+# Evaluation JSON content WITHOUT evaluator.role_marker
+EVAL_NO_ROLE_MARKER='{
+  "phase": "GATE:QUALITY",
+  "issue": "#29",
+  "evaluator": "evaluation-ai",
+  "scores": {
+    "correctness": { "score": 8, "reason": "meets requirements" },
+    "quality": { "score": 7, "reason": "clean code" },
+    "test_coverage": { "score": 8, "reason": "good coverage" },
+    "consistency": { "score": 9, "reason": "aligned with principles" },
+    "documentation": { "score": 7, "reason": "docs updated" }
+  }
+}'
+
+# Evaluation JSON content WITH evaluator.role_marker present
+EVAL_WITH_ROLE_MARKER='{
+  "phase": "GATE:QUALITY",
+  "issue": "#29",
+  "evaluator": {
+    "role_marker": "evaluation-ai",
+    "session_id": "sess-abc123"
+  },
+  "scores": {
+    "correctness": { "score": 8, "reason": "meets requirements" },
+    "quality": { "score": 7, "reason": "clean code" },
+    "test_coverage": { "score": 8, "reason": "good coverage" },
+    "consistency": { "score": 9, "reason": "aligned with principles" },
+    "documentation": { "score": 7, "reason": "docs updated" }
+  },
+  "average": 7.8,
+  "verdict": "PASS"
+}'
+
+echo "=== Test Suite: evaluator.role_marker PreToolUse validation (Issue #29) ==="
+echo ""
+
+# ===========================================================================
+# AC1: Hook blocks Write to *.autoflow-state/*/evaluation.json
+#      when evaluator.role_marker is absent → exit code 2
+# ===========================================================================
+echo "--- AC1: Write to evaluation.json without role_marker → blocked (exit 2) ---"
+setup_test_dir
+PAYLOAD=$(make_write_payload "/tmp/repo/.autoflow-state/29/evaluation.json" "$EVAL_NO_ROLE_MARKER")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 2 "$exit_code" \
+  "AC1a: hook exits 2 when Write to evaluation.json lacks role_marker"
+assert_stderr_contains "${TEST_DIR}/hook.err" "role_marker" \
+  "AC1b: stderr mentions role_marker"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC2: Hook blocks Write to *.autoflow-state/*/evaluation/*.json
+#      when evaluator.role_marker is absent → exit code 2
+# ===========================================================================
+echo "--- AC2: Write to evaluation/<name>.json without role_marker → blocked (exit 2) ---"
+setup_test_dir
+PAYLOAD=$(make_write_payload "/tmp/repo/.autoflow-state/29/evaluation/quality.json" "$EVAL_NO_ROLE_MARKER")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 2 "$exit_code" \
+  "AC2a: hook exits 2 when Write to evaluation/quality.json lacks role_marker"
+assert_stderr_contains "${TEST_DIR}/hook.err" "role_marker" \
+  "AC2b: stderr mentions role_marker"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC3: Hook allows Write to evaluation JSON when
+#      evaluator.role_marker is present and non-empty → exit code 0
+# ===========================================================================
+echo "--- AC3: Write to evaluation.json WITH role_marker → allowed (exit 0) ---"
+setup_test_dir
+PAYLOAD=$(make_write_payload "/tmp/repo/.autoflow-state/29/evaluation.json" "$EVAL_WITH_ROLE_MARKER")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 0 "$exit_code" \
+  "AC3: hook exits 0 when Write to evaluation.json includes role_marker"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC4: Hook allows Edit to evaluation JSON regardless of content → exit code 0
+# (Edit does not carry the full file content, so role_marker check is skipped)
+# ===========================================================================
+echo "--- AC4: Edit to evaluation.json (no role_marker check) → allowed (exit 0) ---"
+setup_test_dir
+PAYLOAD=$(make_edit_payload "/tmp/repo/.autoflow-state/29/evaluation.json")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 0 "$exit_code" \
+  "AC4: hook exits 0 for Edit to evaluation.json (no role_marker check)"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC5: Hook allows MultiEdit to evaluation JSON regardless of content → exit code 0
+# ===========================================================================
+echo "--- AC5: MultiEdit to evaluation.json (no role_marker check) → allowed (exit 0) ---"
+setup_test_dir
+PAYLOAD=$(make_multiedit_payload "/tmp/repo/.autoflow-state/29/evaluation.json")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 0 "$exit_code" \
+  "AC5: hook exits 0 for MultiEdit to evaluation.json (no role_marker check)"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC6: Hook allows Write to non-evaluation JSON files regardless of content
+# (e.g., plan.json — same .autoflow-state/ path but not evaluation.json)
+# ===========================================================================
+echo "--- AC6: Write to non-evaluation JSON (plan.json) → allowed (exit 0) ---"
+setup_test_dir
+PAYLOAD=$(make_write_payload "/tmp/repo/.autoflow-state/29/plan.json" "$EVAL_NO_ROLE_MARKER")
+exit_code=0
+printf '%s' "$PAYLOAD" \
+  | CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+assert_exit_code 0 "$exit_code" \
+  "AC6: hook exits 0 for Write to plan.json (not an evaluation path)"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo "=== Results ==="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+if [ "${#ERRORS[@]}" -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for e in "${ERRORS[@]}"; do
+    echo "  $e"
+  done
+fi
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **`docs/evaluation-system.md`**: Declared as single source of truth for evaluation JSON schema. Updated `evaluator` from flat string to object with `role_marker` and `session_id`. Added `average`, `verdict`, `rationale` fields. Updated Field Descriptions table with gate-specific `role_marker` values.
- **`check-autoflow-gate.sh`**: Added PreToolUse block that rejects `Write` calls to `evaluation.json` / `evaluation/*.json` when `evaluator.role_marker` is absent or empty. Edit/MultiEdit excluded.
- **`CLAUDE.md`**: Updated Evaluation Output Format to match standard schema. Added rule 5 to Evaluation AI Prompt Rules mandating `evaluator.role_marker` output.
- **`CLAUDE.md.template`**: Updated Output Format JSON to match standard schema (removed `overall`, `pass`, `comments`; added structured `evaluator` object and `average`/`verdict`/`rationale` fields).
- **`tests/test-hook-role-marker.sh`**: 8 test cases covering all acceptance criteria (block/allow on Write, Edit/MultiEdit exclusion, non-evaluation path exclusion). All pass.

## Test plan

- [x] `bash tests/test-hook-role-marker.sh` → 8/8 PASS
- [x] GATE:QUALITY score: 8.0 (correctness 8, quality 8, test_coverage 8, consistency 9, documentation 7)
- [x] All acceptance criteria verified:
  - `docs/evaluation-system.md` is now the single source of truth
  - All GATE formats show standard schema with `evaluator.role_marker`
  - Hook blocks Write to evaluation JSON when `role_marker` absent
  - Edit/MultiEdit excluded from check
  - Hook computes average/verdict independently

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)