### PR TITLE
docs(#30): add behavioral rule authoring style meta-principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ This project follows Auto-Flow with Agent Teams. Even though this is a single re
 1. **[MUST]** Include: evaluation type, `CLAUDE.md > [section]` reference, target file paths
 2. **[MUST]** Do NOT copy evaluation criteria into the prompt — instruct the AI to read CLAUDE.md directly
 3. **[MUST]** Orchestrator-written portion must be 5 lines or fewer (excluding target file contents)
-4. **[DENY]** No opinions, interpretations, or leading phrases ("consider that ~", "note that ~", "this is ~ so")
+4. **[MUST]** State observations as direct facts — cite file paths and line numbers. Prohibited forms: "consider that ~", "note that ~", "this is ~ so".
 5. **[MUST]** Evaluation AI output MUST include `evaluator.role_marker` with the gate-specific value: `[role:eval-hypothesis]`, `[role:eval-plan]`, or `[role:eval-quality]`. The hook will block evaluation JSON writes that omit this field.
 
 ### Orchestrator Boundaries

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -167,7 +167,7 @@ All other files require delegation to teammates:
 1. **[MUST]** Include: evaluation type, `CLAUDE.md > [section]` reference, target file paths
 2. **[MUST]** Do NOT copy evaluation criteria into the prompt — instruct the AI to read CLAUDE.md directly
 3. **[MUST]** Orchestrator-written portion must be 5 lines or fewer (excluding target file contents)
-4. **[DENY]** No opinions, interpretations, or leading phrases ("consider that ~", "note that ~", "this is ~ so")
+4. **[MUST]** State observations as direct facts — cite file paths and line numbers. Prohibited forms: "consider that ~", "note that ~", "this is ~ so".
 
 ### Communication Between Agents
 

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -324,7 +324,7 @@ When spawning the Evaluation AI (at GATE:HYPOTHESIS, GATE:PLAN, and GATE:QUALITY
 1. **[MUST]** Include: evaluation type, `CLAUDE.md > [section]` reference, target file paths
 2. **[MUST]** Do NOT copy evaluation criteria into the prompt — instruct the AI to read CLAUDE.md directly
 3. **[MUST]** Orchestrator-written portion must be 5 lines or fewer (excluding target file contents)
-4. **[DENY]** No opinions, interpretations, or leading phrases ("consider that ~", "note that ~", "this is ~ so")
+4. **[MUST]** State observations as direct facts — cite file paths and line numbers. Prohibited forms: "consider that ~", "note that ~", "this is ~ so".
 
 ---
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -222,6 +222,40 @@ The following may look like "better approaches" but undermine core principles:
 
 ---
 
+## Behavioral Rule Authoring Style
+
+Every behavioral rule in this system should have three elements:
+
+1. **The action** — stated in positive form: "the AI does X."
+2. **The reason** — why this action is required.
+3. **Step instructions** — how to perform it, if non-obvious.
+
+**Why positive form over negative prohibition**
+
+Negative rules ("do not do X") leave loopholes: an LLM can reason "I did not do X, I did Y instead" and satisfy the prohibition while violating the intent. Positive rules anchor the behavior — "cite file paths and line numbers" is harder to route around than "no vague statements."
+
+The classic failure mode: `[DENY] No opinions or leading phrases` — an LLM can silently reframe an opinion as a "neutral observation" and pass the check. The positive form breaks this: `[MUST] State observations as direct facts — cite file paths and line numbers` gives a concrete, verifiable action.
+
+**Example (before/after)**
+
+Before:
+```
+4. **[DENY]** No opinions, interpretations, or leading phrases ("consider that ~", "note that ~", "this is ~ so")
+```
+
+After:
+```
+4. **[MUST]** State observations as direct facts — cite file paths and line numbers. Prohibited forms: "consider that ~", "note that ~", "this is ~ so".
+```
+
+The "Prohibited forms" note is kept as a supplementary anchor. The rule is now anchored on the positive behavior first.
+
+**When the forbidden-form note is still needed**
+
+A forbidden-form note is appropriate when listing specific prohibited patterns (as above). It is NOT a substitute for stating what the AI should do. Rule of thumb: the `[MUST]` positive action comes first; the prohibited forms are the safety net.
+
+---
+
 ## Summary: The Design Philosophy of This System
 
 **The pipeline's goal is not to get better with each run, but to perform well without bias every single time.**


### PR DESCRIPTION
## Summary

- Add `## Behavioral Rule Authoring Style` section to `docs/design-rationale.md` defining the three-element rule structure (action / reason / steps) and positive-form preference with a before/after example
- Rephrase the single `[DENY]` entry in `CLAUDE.md`, `CLAUDE.md.template`, and `docs/autoflow-guide.md` to positive `[MUST]` form

## Changes

| File | Change |
|------|--------|
| `docs/design-rationale.md` | +34 lines: new "Behavioral Rule Authoring Style" section |
| `CLAUDE.md` | 1 line: `[DENY]` → `[MUST]` positive form |
| `CLAUDE.md.template` | 1 line: same |
| `docs/autoflow-guide.md` | 1 line: same |

## Test plan

- [x] No `[DENY]` tags remain in `CLAUDE.md`, `CLAUDE.md.template`, or `docs/autoflow-guide.md`
- [x] "Behavioral Rule Authoring Style" section present in `docs/design-rationale.md`
- [x] Before/after example pair present in the new section
- [x] Original constraint (no opinions/interpretations/leading phrases) preserved via "Prohibited forms" note
- [x] GATE:QUALITY PASS — average 8.2, all categories ≥ 7

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)