### PR TITLE
feat(#33): unify VERIFY failure paths into TERMINAL:VERIFY-FAILED handler

### DIFF
--- a/.claude/hooks/check-autoflow-gate.sh
+++ b/.claude/hooks/check-autoflow-gate.sh
@@ -68,6 +68,31 @@ END {
                 echo "[AutoFlow Gate] Use the helper: .claude/scripts/phase-set <PHASE> [--note '<text>']" >&2
                 exit 2
               fi
+              # Issue #33: TERMINAL:VERIFY-FAILED writes carry an additional
+              # mechanical prerequisite — the forensic-recorder artifact must
+              # exist alongside the phase file. We inspect the payload content
+              # for the new phase token and, when present, derive the issue
+              # directory from the target path and call the helper. The check
+              # is mechanical (file presence + four required `##` headers); no
+              # message-body interpretation occurs.
+              if printf '%s' "$_autoflow_payload" \
+                  | grep -F -q "TERMINAL:VERIFY-FAILED"; then
+                _autoflow_issue_dir="${_autoflow_target%/phase}"
+                _autoflow_artifact="${_autoflow_issue_dir}/detailed-failure-analysis.md"
+                if [ ! -f "$_autoflow_artifact" ]; then
+                  echo "[AutoFlow Gate] TERMINAL:VERIFY-FAILED blocked: detailed-failure-analysis.md missing at ${_autoflow_artifact}" >&2
+                  echo "[AutoFlow Gate] The forensic-recorder Teammate must produce the artifact before phase-set." >&2
+                  exit 2
+                fi
+                # Header presence check (mechanical; content within each
+                # section is free-form per plan.md §"New artifacts introduced").
+                for _autoflow_hdr in '## Pattern Classification' '## Triggering Message' '## Failing Test Output' '## RED Decision Basis'; do
+                  if ! grep -F -q "$_autoflow_hdr" "$_autoflow_artifact"; then
+                    echo "[AutoFlow Gate] TERMINAL:VERIFY-FAILED blocked: detailed-failure-analysis.md missing required section: ${_autoflow_hdr}" >&2
+                    exit 2
+                  fi
+                done
+              fi
               ;;
             *.autoflow-state/*/*/evaluation.json|*.autoflow-state/*/evaluation.json|*.autoflow-state/*/*/evaluation/*.json|*.autoflow-state/*/evaluation/*.json)
               if [ "$_autoflow_tool" = "Write" ]; then
@@ -411,6 +436,50 @@ check_intake_exists() {
 }
 
 # ---------------------------------------------------------------------------
+# check_detailed_failure_artifact — Issue #33 forensic-recorder gate
+# ---------------------------------------------------------------------------
+# Validates the artifact written by the fresh forensic-recorder Teammate when
+# VERIFY terminates via the unified fail-closed handler (patterns A/B/C).
+#
+# Required section headers (presence-checked; content within each section is
+# free-form per plan.md §"New artifacts introduced"):
+#   ## Pattern Classification
+#   ## Triggering Message
+#   ## Failing Test Output
+#   ## RED Decision Basis
+#
+# Exit codes:
+#   0 — artifact present with all four headers (allow TERMINAL:VERIFY-FAILED)
+#   1 — artifact missing or any required header absent (block transition)
+#
+# role_marker enforcement is intentionally skipped for this artifact:
+# detailed-failure-analysis.md is markdown, not evaluation JSON. The
+# evaluator.role_marker schema applies to evaluation.json paths only (see
+# docs/evaluation-system.md). The forensic-recorder identifies itself via the
+# `[role:forensic-recorder]` role marker named in design-rationale.md and
+# evaluation-system.md, but no JSON-schema check exists for this artifact
+# class — by design, since the forensic-recorder records facts and never
+# emits a verdict, score, or pass/fail field.
+# ---------------------------------------------------------------------------
+check_detailed_failure_artifact() {
+  local issue="$1"
+  local artifact="${STATE_DIR}/${issue}/detailed-failure-analysis.md"
+  if [ ! -f "$artifact" ]; then
+    log_fail "detailed-failure-analysis.md not found: ${artifact}"
+    log_info "TERMINAL:VERIFY-FAILED requires the forensic-recorder artifact"
+    return 1
+  fi
+  local hdr
+  for hdr in '## Pattern Classification' '## Triggering Message' '## Failing Test Output' '## RED Decision Basis'; do
+    if ! grep -F -q "$hdr" "$artifact" 2>/dev/null; then
+      log_fail "detailed-failure-analysis.md missing required section: ${hdr}"
+      return 1
+    fi
+  done
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Main gate logic
 # ---------------------------------------------------------------------------
 main() {
@@ -484,6 +553,14 @@ main() {
     # LAND: human action required
     LAND)
       log_warn "${phase} — waiting for human merge approval"
+      ;;
+
+    # Issue #33: terminal-failure exit from VERIFY. Requires the
+    # forensic-recorder artifact (detailed-failure-analysis.md) with the
+    # four required `##` section headers. No retry, no arbitration.
+    TERMINAL:VERIFY-FAILED)
+      check_detailed_failure_artifact "$issue" || exit 1
+      log_warn "${phase} — run terminated; human reads detailed-failure-analysis.md and revises issue body before re-running"
       ;;
 
     *)

--- a/.claude/scripts/phase-set
+++ b/.claude/scripts/phase-set
@@ -59,7 +59,7 @@ fi
 SUBREPO_ID="${AUTOFLOW_SUBREPO_ID:-self}"
 
 # Single source of truth for valid phase names + standard exit codes.
-readonly VALID_PHASES="PREFLIGHT DIAGNOSE GATE:HYPOTHESIS ARCHITECT GATE:PLAN DISPATCH RED GREEN VERIFY REFINE GATE:SECURITY GATE:QUALITY REVISION SHIP LAND"
+readonly VALID_PHASES="PREFLIGHT DIAGNOSE GATE:HYPOTHESIS ARCHITECT GATE:PLAN DISPATCH RED GREEN VERIFY REFINE GATE:SECURITY GATE:QUALITY REVISION SHIP LAND TERMINAL:VERIFY-FAILED"
 readonly EX_USAGE=64 EX_DATAERR=65 EX_IOERR=73
 
 # ---------------------------------------------------------------------------
@@ -86,7 +86,8 @@ Arguments:
   <PHASE>           One of:
                     PREFLIGHT, DIAGNOSE, GATE:HYPOTHESIS, ARCHITECT,
                     GATE:PLAN, DISPATCH, RED, GREEN, VERIFY, REFINE,
-                    GATE:SECURITY, GATE:QUALITY, REVISION, SHIP, LAND
+                    GATE:SECURITY, GATE:QUALITY, REVISION, SHIP, LAND,
+                    TERMINAL:VERIFY-FAILED
   --note "<text>"   Optional note appended to the history.log line.
   --help            Show this help and exit.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,20 +122,21 @@ evidence: <artifact path or short factual statement>
 ### Phase Definitions
 
 ```
-PREFLIGHT:       Pre-Work         → Git Clean Check, branch creation
-DIAGNOSE:        Issue Analysis    → 3-Phase independent analysis (bias prevention)
-GATE:HYPOTHESIS: Structure Eval   → Evaluation AI (fresh spawn): PASS → continue, FAIL → close issue
-ARCHITECT:       Plan Synthesis    → Merge analyses into implementation plan + acceptance criteria
-GATE:PLAN:       Plan Evaluation   → Evaluation AI (fresh spawn): 5 categories × 10 points
-DISPATCH:        Task Assignment   → TeamCreate + SendMessage to Test AI and Developer AI
-RED:             Test Writing      → Test AI writes tests → Red confirmation
-GREEN:           Implementation    → Developer AI writes minimum code to pass tests
-VERIFY:          Green + Verify    → All tests pass + minimal implementation check
-REFINE:          Refactor          → Developer AI code cleanup, Green re-confirmation
-GATE:QUALITY:    Evaluation        → Evaluation AI (fresh spawn): scored quality assessment
-REVISION:        Revision          → Fix evaluation feedback (if GATE:QUALITY FAIL)
-SHIP:            PR & Review       → Create PR for human review
-LAND:            Merge & Close     → Human approves and merges
+PREFLIGHT:              Pre-Work          → Git Clean Check, branch creation
+DIAGNOSE:               Issue Analysis    → 3-Phase independent analysis (bias prevention)
+GATE:HYPOTHESIS:        Structure Eval    → Evaluation AI (fresh spawn): PASS → continue, FAIL → close issue
+ARCHITECT:              Plan Synthesis    → Merge analyses into implementation plan + acceptance criteria
+GATE:PLAN:              Plan Evaluation   → Evaluation AI (fresh spawn): 5 categories × 10 points
+DISPATCH:               Task Assignment   → TeamCreate + SendMessage to Test AI and Developer AI
+RED:                    Test Writing      → Test AI writes tests → Red confirmation
+GREEN:                  Implementation    → Developer AI writes minimum code to pass tests
+VERIFY:                 Green + Verify    → All tests pass + minimal implementation check
+REFINE:                 Refactor          → Developer AI code cleanup, Green re-confirmation
+GATE:QUALITY:           Evaluation        → Evaluation AI (fresh spawn): scored quality assessment
+REVISION:               Revision          → Fix evaluation feedback (if GATE:QUALITY FAIL)
+SHIP:                   PR & Review       → Create PR for human review
+LAND:                   Merge & Close     → Human approves and merges
+TERMINAL:VERIFY-FAILED: Terminal Failure  → Forensic-recorder writes detailed-failure-analysis.md; run terminates (no retry)
 ```
 
 ### Execution Principles
@@ -167,7 +168,7 @@ LAND:            Merge & Close     → Human approves and merges
 | VERIFY PASS | All Green + minimal impl check | → REFINE |
 | VERIFY FAIL (test issue) | Test incorrect | → RED (fix test → re-Red) |
 | VERIFY FAIL (impl issue) | Implementation incorrect | → GREEN (fix impl) |
-| VERIFY DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
+| VERIFY (Pattern A/B/C signal observed) | Self-reinterpretation, mutual-innocence (round-trip ≥ 1), or counterparty-invalidation message | → TERMINAL:VERIFY-FAILED (no retry, no arbitration) |
 | REFINE | Refactor done, Green maintained | → GATE:QUALITY |
 | GATE:QUALITY PASS | Score >= 7.5, all >= 7 | → SHIP |
 | GATE:QUALITY FAIL | Below threshold | → REVISION |
@@ -185,6 +186,7 @@ LAND:            Merge & Close     → Human approves and merges
 | GREEN↔VERIFY cycle | 3 round-trips | Human intervention |
 | REFINE FAIL | 2 | Skip refactor, keep Green state |
 | GATE:QUALITY FAIL | 3 → REVISION | Human intervention |
+| TERMINAL:VERIFY-FAILED | 0 | Run terminates; human reads detailed-failure-analysis.md and revises issue body before re-running |
 
 ---
 
@@ -382,7 +384,7 @@ Developer AI teammate writes minimum code to pass tests. This is the **only** ph
     ├─ Test issue → fix test → re-Red → GREEN re-entry
     ├─ Implementation issue → fix implementation → VERIFY retry
     ├─ Both need fixes → fix test first → Red → fix impl → Green
-    └─ Deadlock (both claim "no problem") → fresh Evaluation AI arbitrates
+    └─ Pattern A/B/C signal observed → forensic-recorder spawn → TERMINAL:VERIFY-FAILED
 
 5c-3. Minimal implementation check:
     Diff analysis: is there code NOT covered by any test?

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -66,6 +66,7 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 | REVISION | **Revision** | Fix issues from evaluation (if needed) | Re-evaluation PASS |
 | SHIP | **PR & Review** | Create PR for human review | PR submitted |
 | LAND | **Merge & Close** | Merge after human approval | Issue closed |
+| TERMINAL:VERIFY-FAILED | **Terminal Failure** | Forensic-recorder writes detailed-failure-analysis.md when a Pattern A/B/C signal fires during VERIFY; run terminates (no retry, no arbitration) | Artifact written, run halted |
 
 ### Execution Principles
 
@@ -109,7 +110,7 @@ If Git state is not clean after 0-3, stop and report to user. Do NOT proceed to 
 | VERIFY PASS | All Green + minimal impl check | → REFINE |
 | VERIFY FAIL (test issue) | Test incorrect | → RED (fix test → re-Red) |
 | VERIFY FAIL (impl issue) | Implementation incorrect | → GREEN (fix impl) |
-| VERIFY DEADLOCK | Both claim "no problem" | → Evaluation AI arbitrates |
+| VERIFY (Pattern A/B/C signal observed) | Self-reinterpretation, mutual-innocence (round-trip ≥ 1), or counterparty-invalidation message | → TERMINAL:VERIFY-FAILED (no retry, no arbitration) |
 | REFINE | Refactor done, Green maintained | → GATE:QUALITY |
 | GATE:QUALITY (score >= 7.5, all categories >= 7) | PASS | → SHIP |
 | GATE:QUALITY (score < 7.5 or category < 7) | FAIL | → REVISION |
@@ -359,7 +360,7 @@ Developer AI writes minimum code to pass tests. This is the **only** phase where
     ├─ Test issue → fix test → re-Red → GREEN re-entry
     ├─ Implementation issue → fix implementation → VERIFY retry
     ├─ Both need fixes → fix test first → Red → fix impl → Green
-    └─ Deadlock (both claim "no problem") → fresh Evaluation AI arbitrates
+    └─ Pattern A/B/C signal observed → forensic-recorder spawn → TERMINAL:VERIFY-FAILED
 
 5c-3. Minimal implementation check:
     Diff analysis: is there code NOT covered by any test?
@@ -403,6 +404,7 @@ When the change is purely prose (no scripts, no templates with placeholders):
 | GREEN↔VERIFY cycle | 3 round-trips | Human intervention |
 | REFINE FAIL | 2 | Skip refactor, keep Green state |
 | GATE:QUALITY FAIL | 3 → REVISION | Human intervention |
+| TERMINAL:VERIFY-FAILED | 0 | Run terminates; human reads detailed-failure-analysis.md and revises issue body before re-running |
 
 ---
 

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -306,13 +306,165 @@ For the orchestrator's five facilitator facets and four-signal-type outbound sur
   - **Test issue**: Fix test → re-Red → GREEN re-entry
   - **Implementation issue**: Fix implementation → VERIFY retry
   - **Both need fixes**: Fix test first → Red → fix impl → Green
-  - **Deadlock** (both claim "no problem"): Fresh Evaluation AI arbitrates
+  - **Pattern A/B/C signal observed** (self-reinterpretation, mutual-innocence after round-trip ≥ 1, or counterparty-invalidation): the Teammate that observed the signal emits `transition-request from: VERIFY to: TERMINAL:VERIFY-FAILED`; the Orchestrator spawns a fresh forensic-recorder Teammate (role marker `[role:forensic-recorder]`) which records facts to `detailed-failure-analysis.md`; the run terminates. No retry, no arbitration, no verdict.
 - Minimal implementation check: verify no code exists that isn't covered by tests
 
 ### Exit Criteria
 - All tests pass (Green)
 - No uncovered implementation code
 - Max round-trips: GREEN↔VERIFY max 3 cycles → human escalation
+
+---
+
+## TERMINAL:VERIFY-FAILED: Forensic Terminal Exit (Conditional)
+
+**Goal**: When a Pattern A/B/C signal fires during VERIFY, exit fail-closed by recording the failure facts and terminating the run. No verdict is computed; no automatic re-classification occurs.
+
+This phase replaces the previous deadlock-arbitration path (where a fresh Evaluation AI was spawned to adjudicate competing claims) with a unified fail-closed handler that covers three patterns:
+
+- **Pattern A — self-reinterpretation**: a Teammate reframes its own RED/GREEN artifact (e.g., "should be SKIPped", "actually belongs in manual", "expected output should be interpreted differently").
+- **Pattern B — mutual innocence**: both Teammates emit "no problem on my side" (or equivalent) after at least one GREEN↔VERIFY round-trip while a test still fails.
+- **Pattern C — counterparty invalidation**: one Teammate claims the other's RED or GREEN artifact is wrong ("the test is wrong", "RED artifact is incorrect", "must be re-scoped").
+
+### Trigger Detection (Teammate-Side)
+
+When a Teammate emits a matching signal phrase while phase is VERIFY, the Teammate is responsible for also emitting the canonical `transition-request from: VERIFY to: TERMINAL:VERIFY-FAILED` in the same turn. The Orchestrator does not scan message bodies; this preserves the no-interpret-evidence invariant from Decision 8.
+
+### Forensic-Recorder Spawn (Orchestrator-Side)
+
+On receiving the `transition-request`, the Orchestrator:
+
+1. Spawns a fresh **forensic-recorder Teammate** (no team, no history, role marker `[role:forensic-recorder]`).
+2. The forensic-recorder writes `.autoflow-state/<sub-repo-id>/<issue>/detailed-failure-analysis.md` with the four required `##` section headers and reports completion.
+3. The Orchestrator invokes `.claude/scripts/phase-set TERMINAL:VERIFY-FAILED --note "<verbatim evidence>"`.
+4. The Hook validates: phase is VERIFY, the artifact exists and contains the four required headers. If valid, the phase write proceeds; the run is over.
+
+The forensic-recorder is **not** an arbitrator. It records facts only — verdicts, recommendations, scoring numbers, and "next steps" are forbidden contents.
+
+### detailed-failure-analysis.md schema
+
+| Section | Content |
+|---------|---------|
+| `## Pattern Classification` | One of `self-reinterpretation`, `mutual-innocence`, `counterparty-invalidation`. For `self-reinterpretation` only, a sub-classification line is required: `SKIP attempt`, `manual-checklist relocation`, `expected-behavior redefinition`, `test-invalidation claim`, or `other`. |
+| `## Triggering Message` | Verbatim message body and sender identity (Test AI / Developer AI). No paraphrase. |
+| `## Failing Test Output` | Verbatim runner stdout/stderr for the failing test, plus the test identifier. |
+| `## RED Decision Basis` | Excerpt from `delegation.md` (or the AC list) that justified the original RED artifact. |
+
+### Worked Example — Pattern A: Test AI tries to SKIP its own AC after VERIFY fails
+
+#### Setup
+
+- Issue #99 is in VERIFY. Test AI authored AC 3 in `delegation.md`, asserting that `script foo --bar` exits 0.
+- Developer AI implemented `foo`, which exits 1 due to an input-validation guard.
+- The VERIFY test for AC 3 fails.
+
+#### Trigger event
+
+Test AI sends to the Orchestrator:
+
+```
+@test-ai → @orchestrator
+Reviewing AC 3 against the implementation: this assertion should be SKIPped
+because the script's exit-1 guard is the by-design fail-safe.
+
+@orchestrator transition-request
+from: VERIFY
+to: TERMINAL:VERIFY-FAILED
+evidence: .autoflow-state/self/99/detailed-failure-analysis.md
+```
+
+The phrase "should be SKIPped" combined with the VERIFY phase and Test AI being the original author of AC 3 satisfies Pattern A's guards.
+
+#### Forensic artifact (excerpt of detailed-failure-analysis.md)
+
+```markdown
+## Pattern Classification
+self-reinterpretation
+sub-classification: SKIP attempt
+
+## Triggering Message
+sender: test-ai
+body: "this assertion should be SKIPped because the script's exit-1 guard is
+       the by-design fail-safe."
+
+## Failing Test Output
+test_id: AC3 (tests/test-issue-99.sh::ac3_foo_exits_zero)
+stdout/stderr:
+  + foo --bar
+  foo: input validation failed: --bar requires a value
+  AssertionError: expected exit 0 got 1
+
+## RED Decision Basis
+delegation.md (Test AI Instructions, AC 3): "Running `foo --bar` against a
+clean fixture must exit 0. The script must succeed on the documented
+default-input case."
+```
+
+#### Out-of-band resolution
+
+The human reads `detailed-failure-analysis.md`, decides whether AC 3 was mis-scoped (revise the issue body) or whether the implementation truly violates the contract (re-open with corrected delegation), and re-runs Auto-Flow from PREFLIGHT. The forensic-recorder makes no such determination.
+
+### Worked Example — Pattern B: Both Teammates claim "no problem on my side" after round-trip 1
+
+#### Setup
+
+- Issue #100 is in VERIFY for the second time (one prior GREEN↔VERIFY round-trip recorded in `history.log`).
+- A test for AC 5 fails: the function returns `null` where the test expects `[]`.
+- Test AI says the test is correct; Developer AI says the implementation is correct.
+
+#### Trigger event
+
+Within the current VERIFY entry:
+
+```
+@dev-ai → @orchestrator
+Re-checked the implementation; no problem on my side.
+
+@test-ai → @orchestrator
+Re-ran the assertion; nothing to fix on my side.
+
+@orchestrator transition-request
+from: VERIFY
+to: TERMINAL:VERIFY-FAILED
+evidence: .autoflow-state/self/100/detailed-failure-analysis.md
+```
+
+Both Teammates have emitted the Pattern B phrase since the most recent `*->VERIFY` line in `history.log`, and the round-trip count is ≥ 1. Guards satisfied. The forensic-recorder is spawned (NOT an arbitration Evaluation AI).
+
+#### Forensic artifact (excerpt of detailed-failure-analysis.md)
+
+```markdown
+## Pattern Classification
+mutual-innocence
+
+## Triggering Message
+sender: dev-ai
+body: "Re-checked the implementation; no problem on my side."
+
+sender: test-ai
+body: "Re-ran the assertion; nothing to fix on my side."
+
+## Failing Test Output
+test_id: AC5 (tests/test-issue-100.sh::ac5_returns_empty_list)
+stdout/stderr:
+  Expected: []
+  Actual:   null
+
+## RED Decision Basis
+delegation.md (Test AI Instructions, AC 5): "On the empty-input path, the
+function must return an empty list (`[]`). A null return is a contract
+violation."
+```
+
+#### Out-of-band resolution
+
+The human reads the artifact and decides whether the contract should be relaxed to allow `null`, whether the implementation should normalize `null` to `[]`, or whether the AC needs to be split into two separate cases. Auto-Flow is re-entered from PREFLIGHT after the issue body is updated. The forensic-recorder issued no verdict; the previous "Evaluator arbitrates" path is no longer available.
+
+### Exit Criteria
+- `detailed-failure-analysis.md` written by the fresh forensic-recorder Teammate
+- All four required `##` section headers present (Hook-verified)
+- Phase set to `TERMINAL:VERIFY-FAILED`
+- Run terminated; no retry
 
 ---
 
@@ -454,6 +606,7 @@ When a phase fails, the flow regresses — or terminates:
 | GATE:QUALITY (consistency <= 3) | → DISPATCH | Mandatory major rework |
 | SHIP (CI fails) | → RED | Re-test |
 | LAND (human rejects) | → REVISION | Address human feedback |
+| TERMINAL:VERIFY-FAILED | **Run terminates** (0 retries) | Forensic-recorder wrote `detailed-failure-analysis.md`; human reads it and revises issue body before re-running |
 
 ---
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -193,11 +193,11 @@ The four signal types — and the only signal types — that authorize an outbou
 | # | Signal type | Anchored flow event |
 |---|-------------|---------------------|
 | 1 | transition-request acknowledgment | `CLAUDE.md:109-118` — the Orchestrator invokes `phase-set` after a Teammate emits a `transition-request`. |
-| 2 | dispute arbitration trigger | `CLAUDE.md:168` — the Orchestrator spawns a fresh Evaluation AI when VERIFY DEADLOCK occurs. |
+| 2 | forensic-recorder spawn | `CLAUDE.md` Flow Control row "VERIFY (Pattern A/B/C signal observed)" — the Orchestrator spawns a fresh forensic-recorder Teammate (role marker `[role:forensic-recorder]`) when any of the unified VERIFY-failure patterns (A: self-reinterpretation, B: mutual innocence after round-trip ≥ 1, C: counterparty invalidation) fires during VERIFY. The forensic-recorder records facts to `detailed-failure-analysis.md`; it does not arbitrate, score, or issue a verdict. |
 | 3 | deadline reminder | Time Steward — exactly one outbound reminder per task, sent at or after the up-front deadline communicated at DISPATCH. |
 | 4 | gate evaluator spawn | `CLAUDE.md:92` — the Orchestrator spawns a fresh Evaluation AI when entering GATE:HYPOTHESIS, GATE:PLAN, or GATE:QUALITY. The spawn does not violate the no-interpret-evidence invariant because the Orchestrator hands raw artifacts to the Evaluation AI without reading or summarizing them; the Evaluation AI performs all content judgment. |
 
-Signal 2 and signal 4 are listed separately even though both spawn a fresh Evaluation AI. Signal 2 is reactive to a deadlock; signal 4 is proactive at gate entry. Conflating them would suppress the difference between "evaluator as referee" and "evaluator as gatekeeper."
+Signal 2 and signal 4 are distinct: signal 4 spawns a fresh Evaluation AI that scores work and authorizes a gate transition; signal 2 spawns a fresh forensic-recorder Teammate that records facts and authorizes only the transition into TERMINAL:VERIFY-FAILED. Signal 2 has no decision authority — that is what removes the previous arbitration stance.
 
 **Why it works this way**
 
@@ -244,6 +244,24 @@ The host repo is the only writeable home for `.autoflow-state/`. A sub-repo cont
 
 ---
 
+### Decision 11: VERIFY Failures Exit Fail-Closed via Forensic Recording
+
+**What it does**
+
+When any of three signals fires inside VERIFY — Pattern A (self-reinterpretation), Pattern B (mutual innocence after at least one GREEN↔VERIFY round-trip), or Pattern C (counterparty invalidation) — the run terminates in a new non-regressing phase, `TERMINAL:VERIFY-FAILED`. The Orchestrator spawns a fresh forensic-recorder Teammate (role marker `[role:forensic-recorder]`, no team, no history) which writes `.autoflow-state/<sub-repo-id>/<issue>/detailed-failure-analysis.md` with four required `##` section headers (`## Pattern Classification`, `## Triggering Message`, `## Failing Test Output`, `## RED Decision Basis`). The Hook validates the artifact's presence and headers before allowing the phase write; the run is over. There is no verdict, no automatic re-classification, no retry, no message to the user. Out-of-band issue clarification by a human is the resolution.
+
+**Why it works this way**
+
+Auto-Flow cannot solve everything; it must allow clear failure. Three previously distinct patterns — a Teammate reframing its own RED/GREEN artifact, both Teammates simultaneously claiming "no problem on my side" while a test still fails, and one Teammate invalidating the other's artifact — share a common shape: the system has reached a state where Auto-Flow's mechanical guardrails (test pass/fail, GREEN↔VERIFY 3-cycle cap) cannot distinguish "the work is done" from "the participants disagree about what done means." Continuing the cycle in this state propagates the disagreement; spawning an arbitrator-style Evaluator (the previous design) reintroduces content-judgment into a phase whose mechanical guards are exhausted, which is exactly the Decision 8 Model 2 defect re-emerging under a new label. The fail-closed handler instead records the disagreement as fact and stops, returning the judgment to the human at the issue level — the only party with the authority to revise the issue body, the AC list, or the implementation contract.
+
+The forensic-recorder is intentionally constrained to recording, not arbitration. Forbidden contents — verdicts, recommendations, scoring numbers, "next steps" suggestions — are forbidden specifically because the moment the recorder offers a recommendation, the next iteration's Orchestrator or Teammate will treat the recommendation as authoritative and the fail-closed boundary collapses back into arbitration. Symmetrically, no new verdict enumeration is introduced anywhere in this design; `[role:forensic-recorder]` is purely a recording role and no arbitration role marker exists.
+
+**What this means**
+
+Out of scope for this decision: no new verdict enumeration, no automatic re-classification of test artifacts during VERIFY, no arbitration-style Evaluator spawn at VERIFY, no message to the user on terminal failure. The previous arbitration path is gone, not paused — re-introducing it requires a separate decision with its own rationale (and a separate signal type in the Decision 9 table). The GREEN↔VERIFY 3-cycle cap continues to operate independently for runs that never emit a Pattern A/B/C trigger; the new path is parallel, not a replacement.
+
+---
+
 ## Evaluation System Design Intent
 
 ### Why Scoring Criteria Are Not Fixed
@@ -275,6 +293,7 @@ The following may look like "better approaches" but undermine core principles:
 | Design loops without termination conditions | No maximum retry → infinite loop risk → system hangs |
 | Let a Teammate send a phase-transition request to another Teammate | Bypasses the Orchestrator — no party authorizes peer transitions, breaks the three-party split |
 | Send Orchestrator messages outside the four enumerated signal types | Discretionary outbound messaging reintroduces content judgment by the Orchestrator and breaks the closed signal surface defined in Decision 9 |
+| Auto-reclassify a test artifact during VERIFY (e.g., silently mark an AC as SKIP, relocate it to a manual checklist, or redefine its expected output) | Pattern A self-reinterpretation — collapses the RED contract and bypasses TERMINAL:VERIFY-FAILED; the forensic-recorder must record the attempt, not honor it (Decision 11) |
 
 ---
 

--- a/docs/evaluation-system.md
+++ b/docs/evaluation-system.md
@@ -158,6 +158,15 @@ The Evaluation AI produces a JSON report saved to `.autoflow-state/<issue>/evalu
 >
 > **Important**: The hook enforces that `evaluator.role_marker` is present and non-empty on every Write to an evaluation JSON file. A flat `"evaluator": "string"` will be blocked.
 
+### Non-Evaluation Role Markers
+
+`[role:forensic-recorder]` names the fresh Teammate spawned by the Orchestrator at TERMINAL:VERIFY-FAILED to write `detailed-failure-analysis.md` (see [design-rationale.md > Decision 11](design-rationale.md#decision-11-verify-failures-exit-fail-closed-via-forensic-recording)). This role is intentionally **excluded** from the evaluator role-marker schema and from the `evaluator.role_marker` Hook check, for two reasons:
+
+1. `detailed-failure-analysis.md` is markdown, not JSON. The `evaluator.role_marker` enforcement at the Hook applies to evaluation JSON paths only (`evaluation.json` and the per-gate evaluation files under `.autoflow-state/<id>/<n>/evaluation/*.json`).
+2. The forensic-recorder records facts and never emits a verdict, score, or pass/fail field. Subjecting it to the evaluation-JSON schema would imply a verdict surface the role does not have.
+
+The role marker itself is named here so that Teammates spawned for forensic recording self-identify, but no schema-level check exists for this artifact class — by design.
+
 ---
 
 ## Evaluation Process

--- a/tests/test-issue-33-verify-terminal.sh
+++ b/tests/test-issue-33-verify-terminal.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: Issue #33 — VERIFY-DEADLOCK → unified fail-closed handler
+# =============================================================================
+# Encodes the 14 [automated] acceptance criteria from
+#   .autoflow-state/autoflow-upstream/33/plan.md §"Acceptance criteria"
+#
+# AC numbering matches plan.md exactly.
+#
+# Style follows tests/test-issue-40-doc-sync.sh and tests/test-phase-set.sh:
+#   - set -euo pipefail
+#   - mktemp -d for isolated state fixtures
+#   - POSIX grep/awk only; no GNU extensions; no `sed -i` without backup
+#   - One test function per AC; PASS/FAIL printed inline; aggregate at the end
+#
+# Manual ACs (13, 14 — worked-example markdown blocks in
+# docs/autoflow-guide.md) are listed in the "Manual verification checklist"
+# comment block at the end of this file.
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+CLAUDE_TEMPLATE="${REPO_ROOT}/CLAUDE.md.template"
+AUTOFLOW_GUIDE="${REPO_ROOT}/docs/autoflow-guide.md"
+DESIGN_RATIONALE="${REPO_ROOT}/docs/design-rationale.md"
+EVAL_SYSTEM="${REPO_ROOT}/docs/evaluation-system.md"
+PHASE_SET="${REPO_ROOT}/.claude/scripts/phase-set"
+HOOK="${REPO_ROOT}/.claude/hooks/check-autoflow-gate.sh"
+TEST_PHASE_SET="${REPO_ROOT}/tests/test-phase-set.sh"
+TEST_HOOK_ROLE_MARKER="${REPO_ROOT}/tests/test-hook-role-marker.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: $1")
+  echo "  FAIL: $1"
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (mirror tests/test-phase-set.sh conventions)
+# ---------------------------------------------------------------------------
+TEST_DIR=""
+
+setup_test_dir() {
+  TEST_DIR=$(mktemp -d)
+}
+
+cleanup_test_dir() {
+  if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+  TEST_DIR=""
+}
+
+# Write a valid detailed-failure-analysis.md under a given dir. The four
+# required headers from plan.md §"New artifacts introduced" are present.
+write_valid_failure_artifact() {
+  local target="$1"
+  cat > "$target" <<'ARTIFACT'
+# Detailed Failure Analysis
+
+## Pattern Classification
+self-reinterpretation
+sub-classification: SKIP attempt
+
+## Triggering Message
+sender: test-ai
+body: this AC should be SKIPped because the test is misclassified
+
+## Failing Test Output
+test_id: T1
+stdout/stderr:
+  AssertionError: expected exit 0 got 1
+
+## RED Decision Basis
+delegation.md AC 1 stated the script must exit 0; the test follows that contract.
+ARTIFACT
+}
+
+echo "=== Test Suite: Issue #33 — VERIFY terminal failure path ==="
+echo ""
+
+# ===========================================================================
+# AC 1: grep -c "VERIFY DEADLOCK" services/autoflow-upstream/CLAUDE.md → 0
+# ===========================================================================
+echo "--- AC 1: CLAUDE.md must not contain 'VERIFY DEADLOCK' ---"
+if [ ! -f "$CLAUDE_MD" ]; then
+  fail "AC1: CLAUDE.md not found"
+else
+  count=$(grep -c "VERIFY DEADLOCK" "$CLAUDE_MD" || true)
+  if [ "$count" = "0" ]; then
+    pass "AC1: CLAUDE.md contains 0 occurrences of 'VERIFY DEADLOCK'"
+  else
+    fail "AC1: CLAUDE.md contains $count occurrence(s) of 'VERIFY DEADLOCK' (expected 0)"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 2: grep -c "VERIFY DEADLOCK" services/autoflow-upstream/CLAUDE.md.template → 0
+# ===========================================================================
+echo "--- AC 2: CLAUDE.md.template must not contain 'VERIFY DEADLOCK' ---"
+if [ ! -f "$CLAUDE_TEMPLATE" ]; then
+  fail "AC2: CLAUDE.md.template not found"
+else
+  count=$(grep -c "VERIFY DEADLOCK" "$CLAUDE_TEMPLATE" || true)
+  if [ "$count" = "0" ]; then
+    pass "AC2: CLAUDE.md.template contains 0 occurrences of 'VERIFY DEADLOCK'"
+  else
+    fail "AC2: CLAUDE.md.template contains $count occurrence(s) of 'VERIFY DEADLOCK' (expected 0)"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 3: 'Evaluation AI arbitrates' must be absent from CLAUDE.md,
+# CLAUDE.md.template, and docs/autoflow-guide.md.
+# ===========================================================================
+echo "--- AC 3: 'Evaluation AI arbitrates' must be absent from three files ---"
+for f in "$CLAUDE_MD" "$CLAUDE_TEMPLATE" "$AUTOFLOW_GUIDE"; do
+  if [ ! -f "$f" ]; then
+    fail "AC3: file not found: $f"
+    continue
+  fi
+  count=$(grep -c "Evaluation AI arbitrates" "$f" || true)
+  if [ "$count" = "0" ]; then
+    pass "AC3: $(basename "$f") contains 0 occurrences of 'Evaluation AI arbitrates'"
+  else
+    fail "AC3: $(basename "$f") contains $count occurrence(s) of 'Evaluation AI arbitrates' (expected 0)"
+  fi
+done
+echo ""
+
+# ===========================================================================
+# AC 4: phase-set must list TERMINAL:VERIFY-FAILED inside VALID_PHASES.
+# Approach: extract the VALID_PHASES line (begins with VALID_PHASES= or
+# `readonly VALID_PHASES=`), then grep for the new phase token inside it.
+# ===========================================================================
+echo "--- AC 4: phase-set VALID_PHASES must contain 'TERMINAL:VERIFY-FAILED' ---"
+if [ ! -f "$PHASE_SET" ]; then
+  fail "AC4: phase-set script not found"
+else
+  valid_phases_line=$(awk '
+    /VALID_PHASES[[:space:]]*=/ { print; exit }
+  ' "$PHASE_SET")
+  if [ -z "$valid_phases_line" ]; then
+    fail "AC4: VALID_PHASES assignment line not found in phase-set"
+  else
+    if printf '%s' "$valid_phases_line" | grep -F -q "TERMINAL:VERIFY-FAILED"; then
+      pass "AC4: VALID_PHASES line contains 'TERMINAL:VERIFY-FAILED'"
+    else
+      fail "AC4: VALID_PHASES line does not contain 'TERMINAL:VERIFY-FAILED' (line: $valid_phases_line)"
+    fi
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 5: phase-set TERMINAL:VERIFY-FAILED with phase=VERIFY and a valid
+# detailed-failure-analysis.md exits 0 and writes the new phase.
+# Fixture uses self/33 namespace.
+# ===========================================================================
+echo "--- AC 5: phase-set TERMINAL:VERIFY-FAILED happy path → exit 0 + phase written ---"
+setup_test_dir
+mkdir -p "${TEST_DIR}/.autoflow-state/self/33"
+echo "self/33" > "${TEST_DIR}/.autoflow-state/current-issue"
+echo "VERIFY" > "${TEST_DIR}/.autoflow-state/self/33/phase"
+write_valid_failure_artifact \
+  "${TEST_DIR}/.autoflow-state/self/33/detailed-failure-analysis.md"
+
+exit_code=0
+CLAUDE_PROJECT_DIR="$TEST_DIR" \
+  bash "$PHASE_SET" TERMINAL:VERIFY-FAILED \
+    > "${TEST_DIR}/stdout.txt" 2> "${TEST_DIR}/stderr.txt" \
+  || exit_code=$?
+
+if [ "$exit_code" -eq 0 ]; then
+  pass "AC5a: phase-set TERMINAL:VERIFY-FAILED exits 0 on valid fixture"
+else
+  fail "AC5a: phase-set TERMINAL:VERIFY-FAILED exited $exit_code (expected 0); stderr: $(cat "${TEST_DIR}/stderr.txt" 2>/dev/null || true)"
+fi
+
+PHASE_FILE="${TEST_DIR}/.autoflow-state/self/33/phase"
+if [ -f "$PHASE_FILE" ] && [ "$(cat "$PHASE_FILE")" = "TERMINAL:VERIFY-FAILED" ]; then
+  pass "AC5b: phase file equals 'TERMINAL:VERIFY-FAILED'"
+else
+  actual=$(cat "$PHASE_FILE" 2>/dev/null || echo "<missing>")
+  fail "AC5b: phase file content is '$actual' (expected 'TERMINAL:VERIFY-FAILED')"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC 6: Hook (PreToolUse Write) targeting the phase file with phase=VERIFY
+# but missing detailed-failure-analysis.md must exit 2 with stderr mentioning
+# 'detailed-failure-analysis'. We invoke the hook directly with a JSON
+# payload simulating the phase-set write attempt; the AUTOFLOW_PHASE_SET=1
+# sentinel is set so the existing direct-write block does NOT swallow the
+# event — the new TERMINAL:VERIFY-FAILED guard must take over.
+# ===========================================================================
+echo "--- AC 6: hook blocks TERMINAL:VERIFY-FAILED transition without artifact ---"
+setup_test_dir
+mkdir -p "${TEST_DIR}/.autoflow-state/self/33"
+echo "self/33" > "${TEST_DIR}/.autoflow-state/current-issue"
+echo "VERIFY" > "${TEST_DIR}/.autoflow-state/self/33/phase"
+# Deliberately do NOT write detailed-failure-analysis.md.
+
+PAYLOAD_AC6=$(printf '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"%s/.autoflow-state/self/33/phase","content":"TERMINAL:VERIFY-FAILED\n"}}' "$TEST_DIR")
+
+exit_code=0
+printf '%s' "$PAYLOAD_AC6" \
+  | AUTOFLOW_PHASE_SET=1 CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+
+if [ "$exit_code" -eq 2 ]; then
+  pass "AC6a: hook exits 2 when TERMINAL:VERIFY-FAILED requested without artifact"
+else
+  fail "AC6a: hook exited $exit_code (expected 2); stderr: $(cat "${TEST_DIR}/hook.err" 2>/dev/null || true)"
+fi
+
+if grep -q "detailed-failure-analysis" "${TEST_DIR}/hook.err" 2>/dev/null \
+    || grep -q "detailed-failure-analysis" "${TEST_DIR}/hook.out" 2>/dev/null; then
+  pass "AC6b: hook output mentions 'detailed-failure-analysis'"
+else
+  fail "AC6b: hook output does not mention 'detailed-failure-analysis'"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# AC 7: '[role:forensic-recorder]' must appear in BOTH
+# docs/design-rationale.md AND docs/evaluation-system.md.
+# Use grep -F (literal) so the brackets are not regex-interpreted.
+# ===========================================================================
+echo "--- AC 7: '[role:forensic-recorder]' must appear in design-rationale + evaluation-system ---"
+for f in "$DESIGN_RATIONALE" "$EVAL_SYSTEM"; do
+  if [ ! -f "$f" ]; then
+    fail "AC7: file not found: $f"
+    continue
+  fi
+  if grep -F -q "[role:forensic-recorder]" "$f"; then
+    pass "AC7: $(basename "$f") contains '[role:forensic-recorder]'"
+  else
+    fail "AC7: $(basename "$f") missing '[role:forensic-recorder]'"
+  fi
+done
+echo ""
+
+# ===========================================================================
+# AC 8: design-rationale.md has '### Decision 11' header AND the section
+# between '### Decision 11' and the next '### ' contains the literal phrase
+# 'Auto-Flow cannot solve everything' (case-sensitive).
+# ===========================================================================
+echo "--- AC 8: design-rationale.md '### Decision 11' section contains the rationale phrase ---"
+if [ ! -f "$DESIGN_RATIONALE" ]; then
+  fail "AC8: design-rationale.md not found"
+else
+  if grep -Eq "^### Decision 11" "$DESIGN_RATIONALE"; then
+    pass "AC8a: '### Decision 11' header found"
+  else
+    fail "AC8a: '### Decision 11' header missing"
+  fi
+
+  decision_11_body=$(awk '
+    /^### Decision 11/ { in_section = 1; print; next }
+    in_section && /^### / { in_section = 0 }
+    in_section { print }
+  ' "$DESIGN_RATIONALE")
+
+  if printf '%s' "$decision_11_body" | grep -F -q "Auto-Flow cannot solve everything"; then
+    pass "AC8b: Decision 11 section contains 'Auto-Flow cannot solve everything'"
+  else
+    fail "AC8b: Decision 11 section missing 'Auto-Flow cannot solve everything'"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 9: design-rationale.md must NO LONGER contain
+#   'dispute arbitration trigger' (Signal 2 row replaced)
+#   'evaluator as referee' (Decision 9 narrative updated)
+# ===========================================================================
+echo "--- AC 9: design-rationale.md must remove deprecated phrases ---"
+if [ ! -f "$DESIGN_RATIONALE" ]; then
+  fail "AC9: design-rationale.md not found"
+else
+  for phrase in "dispute arbitration trigger" "evaluator as referee"; do
+    if grep -F -q "$phrase" "$DESIGN_RATIONALE"; then
+      fail "AC9: design-rationale.md still contains '$phrase'"
+    else
+      pass "AC9: design-rationale.md no longer contains '$phrase'"
+    fi
+  done
+fi
+echo ""
+
+# ===========================================================================
+# AC 10: pre-existing tests/test-phase-set.sh exits 0 with the new
+# VALID_PHASES list. We run it via bash from REPO_ROOT.
+# ===========================================================================
+echo "--- AC 10: tests/test-phase-set.sh still exits 0 ---"
+if [ ! -f "$TEST_PHASE_SET" ]; then
+  fail "AC10: tests/test-phase-set.sh not found"
+else
+  exit_code=0
+  ( cd "$REPO_ROOT" && bash "$TEST_PHASE_SET" ) \
+    > /tmp/test-issue-33-phase-set.out 2>&1 \
+    || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass "AC10: tests/test-phase-set.sh exits 0 (no regression)"
+  else
+    fail "AC10: tests/test-phase-set.sh exited $exit_code (output saved to /tmp/test-issue-33-phase-set.out)"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 11: pre-existing tests/test-hook-role-marker.sh exits 0 (existing
+# evaluator.role_marker enforcement on evaluation.json paths is unchanged).
+# ===========================================================================
+echo "--- AC 11: tests/test-hook-role-marker.sh still exits 0 ---"
+if [ ! -f "$TEST_HOOK_ROLE_MARKER" ]; then
+  fail "AC11: tests/test-hook-role-marker.sh not found"
+else
+  exit_code=0
+  ( cd "$REPO_ROOT" && bash "$TEST_HOOK_ROLE_MARKER" ) \
+    > /tmp/test-issue-33-role-marker.out 2>&1 \
+    || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass "AC11: tests/test-hook-role-marker.sh exits 0 (no regression)"
+  else
+    fail "AC11: tests/test-hook-role-marker.sh exited $exit_code (output saved to /tmp/test-issue-33-role-marker.out)"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 12: PreToolUse Write payload targeting
+# .autoflow-state/<sub>/<n>/detailed-failure-analysis.md is allowed by the
+# hook (exit 0) WITHOUT requiring an evaluator.role_marker field. The
+# payload body deliberately omits role_marker; the hook MUST treat the
+# artifact class as exempt (markdown, not evaluation JSON).
+#
+# Two-part assertion:
+#  AC12a: behavior — the hook exits 0 on the Write payload.
+#  AC12b: source-level evidence — check_detailed_failure_artifact helper
+#         (added by plan §"Files changed") exists in the hook AND its
+#         comment-block (per delegation.md "GATE:PLAN evaluator addenda"
+#         item 3) explicitly states why role_marker enforcement is
+#         intentionally skipped for this artifact. AC12b is the new-content
+#         specific assertion that fails against the current repo.
+# ===========================================================================
+echo "--- AC 12: hook allows Write to detailed-failure-analysis.md without role_marker ---"
+setup_test_dir
+PAYLOAD_AC12=$(printf '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/x/.autoflow-state/self/33/detailed-failure-analysis.md","content":"## Pattern Classification\\nself-reinterpretation\\n"}}')
+exit_code=0
+printf '%s' "$PAYLOAD_AC12" \
+  | env -u AUTOFLOW_PHASE_SET CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$HOOK" \
+    > "${TEST_DIR}/hook.out" 2> "${TEST_DIR}/hook.err" \
+  || exit_code=$?
+if [ "$exit_code" -eq 0 ]; then
+  pass "AC12a: hook exits 0 for Write to detailed-failure-analysis.md (no role_marker needed)"
+else
+  fail "AC12a: hook exited $exit_code for Write to detailed-failure-analysis.md (expected 0); stderr: $(cat "${TEST_DIR}/hook.err" 2>/dev/null || true)"
+fi
+cleanup_test_dir
+
+# AC12b: source-level evidence. The hook MUST contain a helper called
+# `check_detailed_failure_artifact` AND a comment near it explaining that
+# role_marker enforcement is intentionally skipped for this artifact.
+if [ ! -f "$HOOK" ]; then
+  fail "AC12b: check-autoflow-gate.sh not found"
+else
+  if grep -F -q "check_detailed_failure_artifact" "$HOOK"; then
+    helper_block=$(awk '
+      /check_detailed_failure_artifact/ { in_block = 1 }
+      in_block { print; lines++ }
+      in_block && lines > 80 { exit }
+    ' "$HOOK")
+    if printf '%s' "$helper_block" | grep -F -q "role_marker"; then
+      pass "AC12b: check_detailed_failure_artifact helper documents role_marker exclusion"
+    else
+      fail "AC12b: check_detailed_failure_artifact helper missing role_marker exclusion comment"
+    fi
+  else
+    fail "AC12b: check_detailed_failure_artifact helper not present in check-autoflow-gate.sh"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 15: design-rationale.md must contain the literal phrase
+# 'no new verdict enumeration' (Decision 11 explicitly states the
+# out-of-scope items).
+# ===========================================================================
+echo "--- AC 15: design-rationale.md must contain 'no new verdict enumeration' ---"
+if [ ! -f "$DESIGN_RATIONALE" ]; then
+  fail "AC15: design-rationale.md not found"
+else
+  if grep -F -q "no new verdict enumeration" "$DESIGN_RATIONALE"; then
+    pass "AC15: design-rationale.md contains 'no new verdict enumeration'"
+  else
+    fail "AC15: design-rationale.md missing 'no new verdict enumeration'"
+  fi
+fi
+echo ""
+
+# ===========================================================================
+# AC 16: 'TERMINAL:VERIFY-FAILED' must appear in check-autoflow-gate.sh
+# inside the `case "$phase"` switch (not just in a comment elsewhere).
+# Approach: extract the lines starting at the `case "$phase"` opener up to
+# the matching `esac`, then grep for the token in that slice.
+# ===========================================================================
+echo "--- AC 16: check-autoflow-gate.sh case \"\$phase\" switch contains 'TERMINAL:VERIFY-FAILED' ---"
+if [ ! -f "$HOOK" ]; then
+  fail "AC16: check-autoflow-gate.sh not found"
+else
+  # Extract the block from the line containing `case "$phase"` to the next
+  # standalone `esac`. POSIX awk; no GNU extensions.
+  case_phase_block=$(awk '
+    /case[[:space:]]*"\$phase"/ { in_block = 1; print; next }
+    in_block { print }
+    in_block && /^[[:space:]]*esac[[:space:]]*$/ { in_block = 0; exit }
+  ' "$HOOK")
+
+  if [ -z "$case_phase_block" ]; then
+    fail "AC16: could not locate 'case \"\$phase\"' block in check-autoflow-gate.sh"
+  else
+    if printf '%s' "$case_phase_block" | grep -F -q "TERMINAL:VERIFY-FAILED"; then
+      pass "AC16: 'TERMINAL:VERIFY-FAILED' appears inside the case \"\$phase\" switch"
+    else
+      fail "AC16: 'TERMINAL:VERIFY-FAILED' not found inside the case \"\$phase\" switch"
+    fi
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi
+
+# =============================================================================
+# Manual verification checklist (NOT automated — covers plan.md ACs 13, 14)
+# =============================================================================
+# Per delegation.md "GATE:PLAN evaluator addenda" item 2, each worked example
+# in docs/autoflow-guide.md MUST follow this exact heading layout so the
+# manual check is mechanical:
+#
+#   ### Worked Example — Pattern <A|B>: <one-line title>
+#   #### Setup
+#   #### Trigger event
+#   #### Forensic artifact (excerpt of detailed-failure-analysis.md)
+#   #### Out-of-band resolution
+#
+# Manual checks:
+#
+#   [ ] AC 13: docs/autoflow-guide.md, inside the new TERMINAL:VERIFY-FAILED
+#       section, contains a `### Worked Example — Pattern A: <title>` block
+#       that follows the four-#### sub-heading layout above. The
+#       "Forensic artifact" sub-section excerpt must show all four required
+#       artifact section headers (## Pattern Classification, ## Triggering
+#       Message, ## Failing Test Output, ## RED Decision Basis).
+#
+#   [ ] AC 14: docs/autoflow-guide.md, in the same section, contains a
+#       `### Worked Example — Pattern B: <title>` block following the same
+#       four-#### sub-heading layout. The scenario shows BOTH teammates
+#       emitting "no problem on my side" after round-trip 1, and the
+#       forensic-recorder path executing (NOT the removed Evaluator
+#       arbitration).
+# =============================================================================

--- a/tests/test-tdd-cycle-restoration.sh
+++ b/tests/test-tdd-cycle-restoration.sh
@@ -108,7 +108,7 @@ test_ac6_minimum_implementation() {
 
 # ---------- AC 7: VERIFY phase includes 4 failure paths ----------
 test_ac7_four_failure_paths() {
-  echo "AC7: VERIFY section includes 4 failure paths (test issue, impl issue, both, deadlock)"
+  echo "AC7: VERIFY section includes 4 failure paths (test issue, impl issue, both, Pattern A/B/C -> TERMINAL:VERIFY-FAILED)"
   local section
   section=$(sed -n '/^###* VERIFY/,/^###* REFINE/p' "$TEMPLATE" 2>/dev/null)
   if [ -z "$section" ]; then
@@ -119,27 +119,28 @@ test_ac7_four_failure_paths() {
   echo "$section" | grep -qiE 'test issue|test incorrect' && paths_found=$((paths_found + 1))
   echo "$section" | grep -qiE 'impl.* issue|implementation.* issue|implementation incorrect' && paths_found=$((paths_found + 1))
   echo "$section" | grep -qiE 'both' && paths_found=$((paths_found + 1))
-  echo "$section" | grep -qiE 'deadlock' && paths_found=$((paths_found + 1))
+  echo "$section" | grep -qiE 'pattern.*a/b/c|terminal:verify-failed|forensic-recorder' && paths_found=$((paths_found + 1))
   if [ "$paths_found" -ge 4 ]; then
-    pass "All 4 failure paths found in VERIFY phase"
+    pass "All 4 failure paths found in VERIFY phase (test issue, impl issue, both, Pattern A/B/C -> TERMINAL:VERIFY-FAILED)"
   else
-    fail "Only $paths_found of 4 failure paths found in VERIFY phase"
+    fail "Only $paths_found of 4 failure paths found in VERIFY phase (expected: test issue, impl issue, both, Pattern A/B/C -> TERMINAL:VERIFY-FAILED)"
   fi
 }
 
-# ---------- AC 8: Deadlock path mentions fresh Evaluation AI ----------
-test_ac8_deadlock_fresh_eval() {
-  echo "AC8: Deadlock path mentions fresh Evaluation AI"
+# ---------- AC 8: VERIFY section references TERMINAL:VERIFY-FAILED handler ----------
+test_ac8_terminal_verify_failed() {
+  echo "AC8: VERIFY section references TERMINAL:VERIFY-FAILED handler with forensic-recorder"
   local section
   section=$(sed -n '/^###* VERIFY/,/^###* REFINE/p' "$TEMPLATE" 2>/dev/null)
   if [ -z "$section" ]; then
-    fail "VERIFY section not found for deadlock check"
+    fail "VERIFY section not found for TERMINAL:VERIFY-FAILED check"
     return
   fi
-  if echo "$section" | grep -qiE 'deadlock.*evaluation.*ai|evaluation.*ai.*arbitrat'; then
-    pass "Deadlock path mentions fresh Evaluation AI"
+  if echo "$section" | grep -qiE 'terminal:verify-failed' &&
+     echo "$section" | grep -qiE 'forensic-recorder'; then
+    pass "VERIFY section references TERMINAL:VERIFY-FAILED and forensic-recorder"
   else
-    fail "Deadlock path does not mention fresh Evaluation AI"
+    fail "VERIFY section missing TERMINAL:VERIFY-FAILED and/or forensic-recorder reference"
   fi
 }
 
@@ -267,7 +268,7 @@ test_ac4_flow_control_transitions
 test_ac5_red_confirmation
 test_ac6_minimum_implementation
 test_ac7_four_failure_paths
-test_ac8_deadlock_fresh_eval
+test_ac8_terminal_verify_failed
 test_ac9_roundtrip_limit
 test_ac10_refactor_green
 test_ac11_guide_substeps


### PR DESCRIPTION
## Summary
- Replace `VERIFY DEADLOCK → fresh Evaluation AI arbitrates` with a single fail-closed handler covering Patterns A (self-reinterpretation), B (mutual innocence after round-trip ≥ 1), and C (counterparty invalidation). All three route to the new non-regressing phase `TERMINAL:VERIFY-FAILED`, where a fresh forensic-recorder Teammate (`[role:forensic-recorder]`) writes `detailed-failure-analysis.md`. No verdicts, no auto-reclassification, no Orchestrator content judgment — out-of-band human issue-body revision is the resolution.
- Wires the new phase across `CLAUDE.md`, `CLAUDE.md.template`, `phase-set` (`VALID_PHASES`), and `check-autoflow-gate.sh` (new `TERMINAL:VERIFY-FAILED` arm + `check_detailed_failure_artifact` helper validating the four required `##` section headers). Adds Decision 11 ("Auto-Flow cannot solve everything") and amends Decision 9 Signal 2 from "dispute arbitration trigger" to "forensic-recorder spawn".
- Adds `tests/test-issue-33-verify-terminal.sh` (14 automated ACs / 22 sub-PASS) and updates two stale assertions in `tests/test-tdd-cycle-restoration.sh` (AC7/AC8) to match the new design.

## Test plan
- [x] `bash tests/test-issue-33-verify-terminal.sh` — 22/22 PASS
- [x] `bash tests/test-tdd-cycle-restoration.sh` — 17/17 PASS (after AC7/AC8 update)
- [x] `bash tests/test-phase-set.sh` — 50/50 PASS (no regression on existing `VALID_PHASES` users)
- [x] `bash tests/test-hook-role-marker.sh` — 8/8 PASS (`evaluator.role_marker` enforcement unchanged for `evaluation.json` paths; `detailed-failure-analysis.md` intentionally excluded)
- [x] All other `tests/test-*.sh` PASS, except two pre-existing failures unrelated to #33 (`tests/test_issue_18_sync.sh`, `tests/test-issue-27-phase-transition-protocol.sh` AC8 — both verified pre-existing via stash baseline)
- [x] GATE:QUALITY: avg 8.4 — correctness 9, quality 8, test_coverage 9, consistency 7, documentation 9. PASS (avg ≥ 7.5, all ≥ 7, consistency > 3).

## Follow-up
GATE:QUALITY evaluator flagged a doc-sync suggestion: `CLAUDE.md:84` still names Signal 2 as "dispute arbitration trigger" inside the Five Facilitator Roles paragraph; the canonical rename to "forensic-recorder spawn" landed in `docs/design-rationale.md:196`. Non-blocking; tracked for a follow-up doc-sync change.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)