### PR TITLE
fix(#45): Type 1 axis 3 → Structural Change Necessity (direction-symmetric)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,8 @@ Spawn AI-A again with Phase A results + AI-B's resolution approaches.
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
 | Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
+> **Note**: "Structural Change Necessity" is intentionally direction-symmetric — additive, extending, reverting, and removing proposals all reach the same numerical ceiling on this axis when the structural change is justified.
+
 **Type 2 (Documentation/Consistency) Scoring:**
 
 | Category | Measures |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,7 +247,7 @@ Spawn AI-A again with Phase A results + AI-B's resolution approaches.
 |---|---|
 | Structural Overlap | Does the proposed resolution duplicate existing mechanisms? (high = no overlap) |
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
-| New Mechanism Necessity | Does this require a new type of mechanism? (high = new mechanism needed) |
+| Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
 **Type 2 (Documentation/Consistency) Scoring:**
 

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -246,7 +246,7 @@ To prevent tunnel-vision bias, DIAGNOSE uses **information isolation** — not j
 |---|---|
 | Structural Overlap | Does the proposed resolution duplicate existing mechanisms? (high = no overlap) |
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
-| New Mechanism Necessity | Does this require a new type of mechanism? (high = new mechanism needed) |
+| Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
 **Type 2 (Documentation/Consistency) Scoring:**
 

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -248,6 +248,8 @@ To prevent tunnel-vision bias, DIAGNOSE uses **information isolation** — not j
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
 | Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
+> **Note**: "Structural Change Necessity" is intentionally direction-symmetric — additive, extending, reverting, and removing proposals all reach the same numerical ceiling on this axis when the structural change is justified.
+
 **Type 2 (Documentation/Consistency) Scoring:**
 
 | Category | Measures |

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -109,6 +109,8 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
 | Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
+> **Note**: "Structural Change Necessity" is intentionally direction-symmetric — additive, extending, reverting, and removing proposals all reach the same numerical ceiling on this axis when the structural change is justified.
+
 **Type 2 (Documentation/Consistency) Scoring:**
 
 | Category | Measures |

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -107,7 +107,7 @@ If Git state is not clean after resolution attempts, **stop and report to user**
 |---|---|
 | Structural Overlap | Does the proposed resolution duplicate existing mechanisms? (high = no overlap) |
 | Code Change Necessity | Is actual code change needed, vs. data/config addition? (high = code change needed) |
-| New Mechanism Necessity | Does this require a new type of mechanism? (high = new mechanism needed) |
+| Structural Change Necessity | Does this require structural change to existing mechanisms? (high = structural change needed — by introducing OR removing a mechanism) |
 
 **Type 2 (Documentation/Consistency) Scoring:**
 

--- a/tests/test-issue-19-eval-criteria.sh
+++ b/tests/test-issue-19-eval-criteria.sh
@@ -95,8 +95,8 @@ check "2a. CLAUDE.md Phase 3 has Structural Overlap category" \
 check "2b. CLAUDE.md Phase 3 has Code Change Necessity category" \
   "echo \"\$CLAUDE_PHASE3\" | grep -q 'Code Change Necessity'"
 
-check "2c. CLAUDE.md Phase 3 has New Mechanism Necessity category" \
-  "echo \"\$CLAUDE_PHASE3\" | grep -q 'New Mechanism Necessity'"
+check "2c. CLAUDE.md Phase 3 has Structural Change Necessity category" \
+  "echo \"\$CLAUDE_PHASE3\" | grep -q 'Structural Change Necessity'"
 
 # Type 2 categories
 check "2d. CLAUDE.md Phase 3 has Content Gap category" \

--- a/tests/test-issue-27-phase-transition-protocol.sh
+++ b/tests/test-issue-27-phase-transition-protocol.sh
@@ -182,35 +182,51 @@ echo ""
 #   - docs/design-rationale.md
 #   - tests/test-issue-27-phase-transition-protocol.sh
 #   - .autoflow-state/27/...
+#
+# Branch-local scope: AC8 only enforces on issue-27's own branch
+# (per plan.md #45 Section 2.9). Outside that branch it is skipped so
+# the issue-27 PR-scope whitelist does not block unrelated work.
 # ============================================================
 echo "--- AC8: Only allowed files modified vs main ---"
 
-TOTAL=$((TOTAL + 1))
-DIFF_FILES=$(git -C "$REPO_ROOT" diff --name-only main..HEAD 2>/dev/null || true)
-FORBIDDEN_FILES=""
-if [ -n "$DIFF_FILES" ]; then
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    case "$f" in
-      CLAUDE.md) ;;
-      CLAUDE.md.template) ;;
-      docs/design-rationale.md) ;;
-      tests/test-issue-27-phase-transition-protocol.sh) ;;
-      .autoflow-state/27/*) ;;
-      .autoflow-state/27) ;;
-      *) FORBIDDEN_FILES="$FORBIDDEN_FILES$f"$'\n' ;;
-    esac
-  done <<EOF
+CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+CURRENT_BRANCH_LC=$(printf '%s' "$CURRENT_BRANCH" | tr '[:upper:]' '[:lower:]')
+AC8_IN_SCOPE=0
+case "$CURRENT_BRANCH_LC" in
+  *27-*|*phase-transition*) AC8_IN_SCOPE=1 ;;
+esac
+
+if [ "$AC8_IN_SCOPE" -eq 1 ]; then
+  TOTAL=$((TOTAL + 1))
+  DIFF_FILES=$(git -C "$REPO_ROOT" diff --name-only main..HEAD 2>/dev/null || true)
+  FORBIDDEN_FILES=""
+  if [ -n "$DIFF_FILES" ]; then
+    while IFS= read -r f; do
+      [ -z "$f" ] && continue
+      case "$f" in
+        CLAUDE.md) ;;
+        CLAUDE.md.template) ;;
+        docs/design-rationale.md) ;;
+        tests/test-issue-27-phase-transition-protocol.sh) ;;
+        .autoflow-state/27/*) ;;
+        .autoflow-state/27) ;;
+        *) FORBIDDEN_FILES="$FORBIDDEN_FILES$f"$'\n' ;;
+      esac
+    done <<EOF
 $DIFF_FILES
 EOF
-fi
+  fi
 
-if [ -z "$FORBIDDEN_FILES" ]; then
-  echo "PASS: 8a. git diff main..HEAD contains no forbidden paths"
+  if [ -z "$FORBIDDEN_FILES" ]; then
+    echo "PASS: 8a. git diff main..HEAD contains no forbidden paths"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: 8a. git diff main..HEAD contains forbidden paths:"
+    printf '%s' "$FORBIDDEN_FILES" | sed 's/^/      /'
+  fi
 else
-  FAILURES=$((FAILURES + 1))
-  echo "FAIL: 8a. git diff main..HEAD contains forbidden paths:"
-  printf '%s' "$FORBIDDEN_FILES" | sed 's/^/      /'
+  TOTAL=$((TOTAL + 1))
+  echo "PASS: 8a. Skipped (branch-local scope; AC8 only enforces on issue-27 branch)"
 fi
 
 echo ""

--- a/tests/test-issue-27-phase-transition-protocol.sh
+++ b/tests/test-issue-27-phase-transition-protocol.sh
@@ -193,7 +193,7 @@ CURRENT_BRANCH=$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || 
 CURRENT_BRANCH_LC=$(printf '%s' "$CURRENT_BRANCH" | tr '[:upper:]' '[:lower:]')
 AC8_IN_SCOPE=0
 case "$CURRENT_BRANCH_LC" in
-  *27-*|*phase-transition*) AC8_IN_SCOPE=1 ;;
+  27-*|*/27-*|*phase-transition*) AC8_IN_SCOPE=1 ;;
 esac
 
 if [ "$AC8_IN_SCOPE" -eq 1 ]; then

--- a/tests/test-issue-45-rubric-direction-symmetric.sh
+++ b/tests/test-issue-45-rubric-direction-symmetric.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Test script for issue #45: Type 1 (Code) rubric axis-3 redefined to
+# "Structural Change Necessity" — direction-symmetric across additive and
+# subtractive proposals. Asserts AC1, AC2, AC3, AC4, AC6 from plan.md.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+CLAUDE_TEMPLATE="$REPO_ROOT/CLAUDE.md.template"
+AUTOFLOW_GUIDE="$REPO_ROOT/docs/autoflow-guide.md"
+
+FAILURES=0
+TOTAL=0
+
+pass() {
+  TOTAL=$((TOTAL + 1))
+  echo "PASS: $1"
+}
+
+fail() {
+  TOTAL=$((TOTAL + 1))
+  FAILURES=$((FAILURES + 1))
+  echo "FAIL: $1"
+}
+
+check() {
+  TOTAL=$((TOTAL + 1))
+  if eval "$2" >/dev/null 2>&1; then
+    echo "PASS: $1"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+  fi
+}
+
+echo "========================================="
+echo "Issue #45: Rubric Direction-Symmetric Axis Tests"
+echo "========================================="
+echo ""
+
+# ============================================================
+# AC1: CLAUDE.md axis-3 wording updated
+# ============================================================
+echo "--- AC1: CLAUDE.md axis-3 renamed ---"
+
+check "AC1a. CLAUDE.md contains 'Structural Change Necessity'" \
+  "grep -F 'Structural Change Necessity' '$CLAUDE_MD'"
+
+check "AC1b. CLAUDE.md does NOT contain 'New Mechanism Necessity'" \
+  "! grep -F 'New Mechanism Necessity' '$CLAUDE_MD'"
+
+echo ""
+
+# ============================================================
+# AC2: CLAUDE.md.template axis-3 wording updated
+# ============================================================
+echo "--- AC2: CLAUDE.md.template axis-3 renamed ---"
+
+check "AC2a. CLAUDE.md.template contains 'Structural Change Necessity'" \
+  "grep -F 'Structural Change Necessity' '$CLAUDE_TEMPLATE'"
+
+check "AC2b. CLAUDE.md.template does NOT contain 'New Mechanism Necessity'" \
+  "! grep -F 'New Mechanism Necessity' '$CLAUDE_TEMPLATE'"
+
+echo ""
+
+# ============================================================
+# AC3: docs/autoflow-guide.md axis-3 wording updated
+# ============================================================
+echo "--- AC3: autoflow-guide.md axis-3 renamed ---"
+
+check "AC3a. autoflow-guide.md contains 'Structural Change Necessity'" \
+  "grep -F 'Structural Change Necessity' '$AUTOFLOW_GUIDE'"
+
+check "AC3b. autoflow-guide.md does NOT contain 'New Mechanism Necessity'" \
+  "! grep -F 'New Mechanism Necessity' '$AUTOFLOW_GUIDE'"
+
+echo ""
+
+# ============================================================
+# AC4: Type 1 (Code) rubric still has exactly 3 axes,
+#      and the axis-name set is exactly
+#      {Structural Overlap, Code Change Necessity, Structural Change Necessity}
+# ============================================================
+echo "--- AC4: Type 1 axis count and name set ---"
+
+# Extract the Type 1 (Code) Scoring block from a file.
+# Block starts at the line containing "**Type 1 (Code) Scoring:**" and ends
+# at the line containing "**Type 2" (next section header).
+# Then keep only data rows that look like "| <Capitalized name> | ..." and
+# exclude the header row "| Category | Measures |" and the separator "|---".
+extract_type1_axes() {
+  local file="$1"
+  awk '
+    /\*\*Type 1 \(Code\) Scoring:\*\*/ { in_block = 1; next }
+    in_block && /\*\*Type 2/           { in_block = 0 }
+    in_block { print }
+  ' "$file" |
+  awk -F'|' '
+    /^\| *Category *\| *Measures *\|/ { next }
+    /^\|[ -]*-+/                      { next }
+    /^\| *[A-Z]/ {
+      name = $2
+      sub(/^ +/, "", name)
+      sub(/ +$/, "", name)
+      print name
+    }
+  '
+}
+
+check_axis_set() {
+  local label="$1"
+  local file="$2"
+  local axes
+  axes="$(extract_type1_axes "$file")"
+  local count
+  count=$(printf '%s\n' "$axes" | grep -c .)
+  if [ "$count" -ne 3 ]; then
+    fail "$label: expected 3 Type 1 axes, found $count"
+    echo "    axes: $(printf '%s\n' "$axes" | tr '\n' ',' )"
+    return
+  fi
+  local sorted_actual sorted_expected
+  sorted_actual=$(printf '%s\n' "$axes" | LC_ALL=C sort)
+  sorted_expected=$(printf '%s\n' "Code Change Necessity" "Structural Change Necessity" "Structural Overlap" | LC_ALL=C sort)
+  if [ "$sorted_actual" = "$sorted_expected" ]; then
+    pass "$label: axis name set matches {Structural Overlap, Code Change Necessity, Structural Change Necessity}"
+  else
+    fail "$label: axis name set mismatch"
+    echo "    expected:"
+    printf '%s\n' "$sorted_expected" | sed 's/^/      /'
+    echo "    actual:"
+    printf '%s\n' "$sorted_actual" | sed 's/^/      /'
+  fi
+}
+
+check_axis_set "AC4a. CLAUDE.md"           "$CLAUDE_MD"
+check_axis_set "AC4b. CLAUDE.md.template"  "$CLAUDE_TEMPLATE"
+check_axis_set "AC4c. autoflow-guide.md"   "$AUTOFLOW_GUIDE"
+
+echo ""
+
+# ============================================================
+# AC6: Worked example — rubric is direction-symmetric.
+#   Scenario A (subtractive proposal): (9, 9, 8) → PASS
+#   Scenario B (fully handled by existing structure): (3, 4, 2) → FAIL
+#
+# Deterministic integer-tenths rounding policy:
+#   sum_x10        = (s1 + s2 + s3) * 10
+#   avg_tenths     = sum_x10 / 3        (integer floor division)
+#   min            = smallest of s1, s2, s3
+#   PASS iff avg_tenths >= 75 AND min >= 7
+# ============================================================
+echo "--- AC6: compute_verdict direction-symmetry ---"
+
+compute_verdict() {
+  local s1="$1" s2="$2" s3="$3"
+  local sum_x10 avg_tenths min
+  sum_x10=$(( (s1 + s2 + s3) * 10 ))
+  avg_tenths=$(( sum_x10 / 3 ))
+  min="$s1"
+  [ "$s2" -lt "$min" ] && min="$s2"
+  [ "$s3" -lt "$min" ] && min="$s3"
+  if [ "$avg_tenths" -ge 75 ] && [ "$min" -ge 7 ]; then
+    echo "PASS"
+  else
+    echo "FAIL"
+  fi
+}
+
+verdict_a="$(compute_verdict 9 9 8)"
+if [ "$verdict_a" = "PASS" ]; then
+  pass "AC6a. Scenario A (9,9,8) → PASS (subtractive proposal not auto-FAILed)"
+else
+  fail "AC6a. Scenario A (9,9,8) expected PASS, got $verdict_a"
+fi
+
+verdict_b="$(compute_verdict 3 4 2)"
+if [ "$verdict_b" = "FAIL" ]; then
+  pass "AC6b. Scenario B (3,4,2) → FAIL (existing-structure case still rejected)"
+else
+  fail "AC6b. Scenario B (3,4,2) expected FAIL, got $verdict_b"
+fi
+
+echo ""
+echo "========================================="
+echo "Results: $((TOTAL - FAILURES))/$TOTAL passed, $FAILURES failed"
+echo "========================================="
+
+if [ "$FAILURES" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Redefine DIAGNOSE Phase 3 Type 1 axis 3 from "New Mechanism Necessity" (direction-biased toward additive change) to "Structural Change Necessity" with explicit bidirectional parenthetical, so revert/removal proposals reach the same numerical ceiling as additions.
- Add a one-line blockquote under the renamed row in all three rubric mirrors (CLAUDE.md, CLAUDE.md.template, docs/autoflow-guide.md) documenting the bidirectional intent for future evaluators.
- Scope `tests/test-issue-27-phase-transition-protocol.sh` AC8 (a pre-existing PR-scope assertion that hardcoded an issue-27 whitelist) to its own branch via a leading-anchored `27-*|*/27-*|*phase-transition*` matcher, so it no longer trips on unrelated future branches.

PASS-rule arithmetic, the 3-axis Type 1 shape, the type-classification protocol, the GATE:PLAN/GATE:QUALITY 5-category weighted system, and `check-autoflow-gate.sh` are all unchanged.

Closes #45.

## Why

The original axis 3 wording structurally penalized any revert/removal proposal regardless of merit. Combined with the global PASS rule "every individual category >= 7", the rubric mechanically auto-FAILed legitimate non-additive change shapes (issue #44 — full revert of #33 — was held at end of DIAGNOSE for exactly this reason). The fix is direction-symmetric scoring without altering what the axis measures.

## Test plan

- [x] Full sub-repo test suite: 13/13 PASS on this branch.
- [x] AC1/AC2/AC3 — `grep -F 'Structural Change Necessity'` matches in CLAUDE.md, CLAUDE.md.template, autoflow-guide.md; `grep -F 'New Mechanism Necessity'` returns zero matches in all three.
- [x] AC4 — Type 1 rubric still has exactly 3 axes; axis-name set is `{Structural Overlap, Code Change Necessity, Structural Change Necessity}`.
- [x] AC5 — `tests/test-phase-set.sh`, `tests/test-hook-role-marker.sh`, `tests/test-issue-19-eval-criteria.sh` all PASS.
- [x] AC6 — `tests/test-issue-45-rubric-direction-symmetric.sh` worked-example: subtractive (9,9,8) → PASS, fully-handled (3,4,2) → FAIL.
- [x] `tests/test-issue-19-eval-criteria.sh` updated 2c assertion in lockstep — no false-regression.
- [x] `tests/test-issue-27-phase-transition-protocol.sh` AC8 conditional skip — issue-27 branches still enforce, others skip with PASS.

## Out of scope

- No PASS-rule changes (avg >= 7.5 / all >= 7 unchanged).
- No Type 2 rubric changes.
- No GATE:PLAN / GATE:QUALITY rubric changes.
- No new phase, no new role marker.
- No host-repo edit (host follows via patch application after merge).
- Issue #44 resume happens separately under the corrected rubric.

## Notes

The DIAGNOSE → GATE:HYPOTHESIS path for this PR hit the very rubric defect being fixed (FAIL with axis 3 = 5 due to directional asymmetry). User-authorized out-of-band override was applied per host CLAUDE.md > "Out-of-band exception"; the override scope was limited to #45's GATE:HYPOTHESIS only and is documented at `.autoflow-state/autoflow-upstream/45/decision-override.md` (not part of this PR; host-only state). GATE:PLAN (avg 9.0) and GATE:QUALITY (avg 8.6) ran normally and PASSed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)