### PR TITLE
docs(#38): add PREFLIGHT 0-2b parent-repo sync sub-step

### DIFF
--- a/CLAUDE.local.md.example
+++ b/CLAUDE.local.md.example
@@ -43,6 +43,19 @@ Use `CLAUDE.local.md` for:
 - Focus on issue #42 only
 ```
 
+### Parent-Repo Sync Procedure (if applicable)
+
+If your host repo tracks an upstream sub-repo via patch-apply, document the sync commands here. The sync runs at **PREFLIGHT step `0-2b`** (see `CLAUDE.md` or `docs/autoflow-guide.md` PREFLIGHT section) — not at an arbitrary time. PREFLIGHT step `0-2b` is the canonical scheduling site; this file holds only the host-specific commands.
+
+```bash
+## Parent-Repo Sync (invoked from PREFLIGHT 0-2b)
+# Example — replace with the procedure for your layout:
+# cd <sub-repo-path> && git pull
+# git diff <previous-tag>..<new-tag> > ../patch/upstream.patch
+# cd .. && git apply patch/upstream.patch
+# git commit -m "chore: apply upstream <version> changes"
+```
+
 ---
 
 ## Setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ LAND:            Merge & Close     → Human approves and merges
 ```
 0-1. git status — no uncommitted changes, no untracked files in working area
 0-2. git fetch origin — sync with remote
+0-2b. If this repo tracks an upstream sub-repo via patch-apply (parent-repo / sub-repo layout), bring the host working tree current with the just-fetched sub-repo state per the host's local procedure (e.g., `CLAUDE.local.md`). Skip if the project is single-repo.
 0-3. Resolve any dirty state (stash, commit, or discard with user approval)
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -84,6 +84,10 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 ```
 0-1. git status — no uncommitted changes, no untracked files in working area
 0-2. git fetch origin — sync with remote
+<!-- BEGIN: OPTIONAL PARENT-REPO SYNC -->
+<!-- Remove this 0-2b line if your project does not use a parent-repo / submodule layout -->
+0-2b. If this repo tracks an upstream sub-repo via patch-apply (parent-repo / sub-repo layout), bring the host working tree current with the just-fetched sub-repo state per the host's local procedure (e.g., `CLAUDE.local.md`). Skip if the project is single-repo.
+<!-- END: OPTIONAL PARENT-REPO SYNC -->
 0-3. Resolve any dirty state (stash, commit, or discard with user approval)
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -23,6 +23,7 @@ The key principles:
 ### Activities
 - `git status` — verify no uncommitted changes or untracked files in working area
 - `git fetch origin` — sync with remote
+- **(Optional, parent-repo / sub-repo layout only)** If this repo tracks an upstream sub-repo via patch-apply, bring the host working tree current with the just-fetched sub-repo state per the host's local procedure (e.g., `CLAUDE.local.md`). Skip if the project is single-repo.
 - Resolve any dirty state (stash, commit, or discard with user approval)
 - `git checkout -b <branch-type>/<issue>-<desc> main` — create feature branch from latest main
 

--- a/tests/test-issue-38-preflight-parent-repo-sync.sh
+++ b/tests/test-issue-38-preflight-parent-repo-sync.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: Issue #38 — PREFLIGHT parent-repo sync sub-step (0-2b)
+# =============================================================================
+# Encodes AC1–AC7 from
+#   .autoflow-state/autoflow-upstream/38/plan.md §6
+#
+# AC1 — PREFLIGHT in CLAUDE.md contains the 0-2b parent-repo sync line,
+#       positioned strictly between 0-2 and 0-3.
+# AC2 — The 0-2b step line is character-identical between CLAUDE.md and
+#       CLAUDE.md.template (mirroring contract from plan §4.1, §4.3).
+# AC3 — CLAUDE.local.md.example has a "### Parent-Repo Sync Procedure"
+#       section that back-references "PREFLIGHT step `0-2b`".
+# AC4 — Optional carrier split:
+#       (a) CLAUDE.md.template wraps the new step in
+#           "<!-- BEGIN/END: OPTIONAL PARENT-REPO SYNC -->" HTML comments.
+#       (b) CLAUDE.md uses prose conditional ("If this repo tracks an
+#           upstream sub-repo via patch-apply" + "Skip if the project is
+#           single-repo.").
+#       (c) CLAUDE.md MUST NOT contain the HTML carrier markers.
+# AC5 — docs/autoflow-guide.md PREFLIGHT Activities list contains a bullet
+#       paraphrasing the 0-2b step ("(Optional, parent-repo / sub-repo
+#       layout only)" + "tracks an upstream sub-repo via patch-apply").
+# AC6 — Regression: every existing test script under
+#       services/autoflow-upstream/tests/ continues to exit 0.
+# AC7 — Negative: the new 0-2b instruction MUST NOT mention
+#       ".autoflow-state" anywhere across the four edited files.
+#
+# Run from inside services/autoflow-upstream/ OR from the host repo root —
+# the script normalizes its working directory via `git rev-parse`.
+# =============================================================================
+
+set -uo pipefail
+# NOTE: not using `set -e` so a single FAIL does not short-circuit the suite.
+
+# ---------------------------------------------------------------------------
+# Resolve REPO_ROOT = services/autoflow-upstream/ regardless of caller cwd.
+# `dirname $0`/.. lands us at the sub-repo root because this script lives at
+# tests/. We then anchor every path under REPO_ROOT.
+# ---------------------------------------------------------------------------
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+CLAUDE_TEMPLATE="${REPO_ROOT}/CLAUDE.md.template"
+AUTOFLOW_GUIDE="${REPO_ROOT}/docs/autoflow-guide.md"
+LOCAL_EXAMPLE="${REPO_ROOT}/CLAUDE.local.md.example"
+TESTS_DIR="${REPO_ROOT}/tests"
+SELF_NAME="$(basename "$0")"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "  PASS: $1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: $1")
+  echo "  FAIL: $1"
+}
+
+echo "=== Test Suite: Issue #38 PREFLIGHT parent-repo sync (0-2b) ==="
+echo "REPO_ROOT: $REPO_ROOT"
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC1 — CLAUDE.md PREFLIGHT contains 0-2b in correct position
+# Plan §2.3.1, §6 AC1.
+# ---------------------------------------------------------------------------
+echo "--- AC1: CLAUDE.md PREFLIGHT contains 0-2b parent-repo sync step ---"
+
+if [ ! -f "$CLAUDE_MD" ]; then
+  fail "AC1-file: CLAUDE.md not found"
+else
+  # AC1a — exactly one 0-2b line within the PREFLIGHT block matches the prose.
+  ac1a_count=$(awk '/^## PREFLIGHT: Pre-Work/,/^---$/' "$CLAUDE_MD" \
+    | grep -E '^0-2b\. If this repo tracks an upstream sub-repo via patch-apply' \
+    | wc -l | tr -d '[:space:]')
+  if [ "$ac1a_count" = "1" ]; then
+    pass "AC1a: exactly one 0-2b prose line in PREFLIGHT block"
+  else
+    fail "AC1a: expected 1 '0-2b. If this repo tracks an upstream sub-repo via patch-apply' line, got $ac1a_count"
+  fi
+
+  # AC1b — order check: 0-2, 0-2b, 0-3 line numbers must be strictly increasing
+  # within the PREFLIGHT block.
+  ordering=$(awk '/^## PREFLIGHT: Pre-Work/,/^---$/' "$CLAUDE_MD" \
+    | grep -nE '^(0-2|0-2b|0-3)\.' \
+    || true)
+  # Extract just the labels in order of appearance.
+  labels_in_order=$(printf '%s\n' "$ordering" | sed -E 's/^[0-9]+:([^.]+)\..*/\1/' | tr '\n' ' ' | sed 's/ $//')
+  if [ "$labels_in_order" = "0-2 0-2b 0-3" ]; then
+    pass "AC1b: PREFLIGHT step order is 0-2 → 0-2b → 0-3"
+  else
+    fail "AC1b: PREFLIGHT step order expected '0-2 0-2b 0-3', got '$labels_in_order'"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC2 — 0-2b step line is character-identical between CLAUDE.md and
+# CLAUDE.md.template. Plan §4.1, §4.3, §6 AC2.
+# ---------------------------------------------------------------------------
+echo "--- AC2: 0-2b step line is character-identical in CLAUDE.md and CLAUDE.md.template ---"
+
+if [ ! -f "$CLAUDE_MD" ] || [ ! -f "$CLAUDE_TEMPLATE" ]; then
+  fail "AC2-files: one or both of CLAUDE.md / CLAUDE.md.template not found"
+else
+  diff_out=$(diff \
+    <(grep -F '0-2b. If this repo tracks an upstream sub-repo' "$CLAUDE_MD") \
+    <(grep -F '0-2b. If this repo tracks an upstream sub-repo' "$CLAUDE_TEMPLATE") \
+    2>&1 || true)
+  if [ -z "$diff_out" ]; then
+    # Empty diff — but only meaningful if both sides actually contain the line.
+    md_has=$(grep -c -F '0-2b. If this repo tracks an upstream sub-repo' "$CLAUDE_MD" || true)
+    tpl_has=$(grep -c -F '0-2b. If this repo tracks an upstream sub-repo' "$CLAUDE_TEMPLATE" || true)
+    if [ "$md_has" -ge 1 ] && [ "$tpl_has" -ge 1 ]; then
+      pass "AC2: 0-2b line matches byte-for-byte between CLAUDE.md and CLAUDE.md.template"
+    else
+      fail "AC2: 0-2b line absent from one or both files (CLAUDE.md=$md_has, template=$tpl_has)"
+    fi
+  else
+    fail "AC2: 0-2b line diverges between CLAUDE.md and CLAUDE.md.template (diff non-empty)"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC3 — CLAUDE.local.md.example has Parent-Repo Sync section back-referencing
+# PREFLIGHT step `0-2b`. Plan §2.4, §6 AC3.
+# ---------------------------------------------------------------------------
+echo "--- AC3: CLAUDE.local.md.example has Parent-Repo Sync section ---"
+
+if [ ! -f "$LOCAL_EXAMPLE" ]; then
+  fail "AC3-file: CLAUDE.local.md.example not found"
+else
+  # AC3a — section header exists exactly once.
+  ac3a_count=$(grep -c '^### Parent-Repo Sync Procedure' "$LOCAL_EXAMPLE" || true)
+  if [ "$ac3a_count" = "1" ]; then
+    pass "AC3a: '### Parent-Repo Sync Procedure' header present (exactly 1)"
+  else
+    fail "AC3a: expected 1 '### Parent-Repo Sync Procedure' header, got $ac3a_count"
+  fi
+
+  # AC3b — the literal back-reference string appears at least once.
+  ac3b_count=$(grep -c -F 'PREFLIGHT step `0-2b`' "$LOCAL_EXAMPLE" || true)
+  if [ "$ac3b_count" -ge 1 ]; then
+    pass "AC3b: 'PREFLIGHT step \`0-2b\`' back-reference present"
+  else
+    fail "AC3b: 'PREFLIGHT step \`0-2b\`' back-reference missing"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC4 — Carrier split: HTML for template, prose for CLAUDE.md, and CLAUDE.md
+# MUST NOT contain the HTML carrier markers. Plan §2.2, §2.3.1, §2.3.2, §6 AC4.
+# ---------------------------------------------------------------------------
+echo "--- AC4: optional-carrier split (HTML in template, prose in CLAUDE.md) ---"
+
+# AC4a — template has BEGIN marker exactly once.
+if [ ! -f "$CLAUDE_TEMPLATE" ]; then
+  fail "AC4a-file: CLAUDE.md.template not found"
+else
+  begin_count=$(grep -c 'BEGIN: OPTIONAL PARENT-REPO SYNC' "$CLAUDE_TEMPLATE" || true)
+  if [ "$begin_count" = "1" ]; then
+    pass "AC4a: CLAUDE.md.template contains 'BEGIN: OPTIONAL PARENT-REPO SYNC' (1 occurrence)"
+  else
+    fail "AC4a: expected 1 'BEGIN: OPTIONAL PARENT-REPO SYNC' in template, got $begin_count"
+  fi
+
+  end_count=$(grep -c 'END: OPTIONAL PARENT-REPO SYNC' "$CLAUDE_TEMPLATE" || true)
+  if [ "$end_count" = "1" ]; then
+    pass "AC4b: CLAUDE.md.template contains 'END: OPTIONAL PARENT-REPO SYNC' (1 occurrence)"
+  else
+    fail "AC4b: expected 1 'END: OPTIONAL PARENT-REPO SYNC' in template, got $end_count"
+  fi
+fi
+
+# AC4c — CLAUDE.md uses prose conditional (antecedent + skip clause).
+if [ ! -f "$CLAUDE_MD" ]; then
+  fail "AC4c-file: CLAUDE.md not found"
+else
+  prose_count=$(grep -F 'If this repo tracks an upstream sub-repo via patch-apply' "$CLAUDE_MD" \
+    | grep -F 'Skip if the project is single-repo.' \
+    | wc -l | tr -d '[:space:]')
+  if [ "$prose_count" = "1" ]; then
+    pass "AC4c: CLAUDE.md prose conditional (antecedent + 'Skip if the project is single-repo.') present"
+  else
+    fail "AC4c: expected 1 prose conditional line in CLAUDE.md, got $prose_count"
+  fi
+
+  # AC4d — CLAUDE.md MUST NOT contain the HTML BEGIN marker.
+  md_html_count=$(grep -c 'BEGIN: OPTIONAL PARENT-REPO SYNC' "$CLAUDE_MD" || true)
+  if [ "$md_html_count" = "0" ]; then
+    pass "AC4d: CLAUDE.md does NOT contain 'BEGIN: OPTIONAL PARENT-REPO SYNC' (carrier is template-only)"
+  else
+    fail "AC4d: CLAUDE.md unexpectedly contains 'BEGIN: OPTIONAL PARENT-REPO SYNC' ($md_html_count occurrences)"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC5 — docs/autoflow-guide.md PREFLIGHT description has the parent-repo
+# bullet (prose form). Plan §2.3.3, §6 AC5.
+# ---------------------------------------------------------------------------
+echo "--- AC5: docs/autoflow-guide.md PREFLIGHT contains parent-repo bullet ---"
+
+if [ ! -f "$AUTOFLOW_GUIDE" ]; then
+  fail "AC5-file: docs/autoflow-guide.md not found"
+else
+  # Extract PREFLIGHT block (between "## PREFLIGHT: Pre-Work" and "### Exit Criteria").
+  preflight_block=$(awk '
+    /^## PREFLIGHT: Pre-Work/ { in_section = 1; print; next }
+    in_section && /^### Exit Criteria/ { in_section = 0 }
+    in_section { print }
+  ' "$AUTOFLOW_GUIDE")
+
+  # AC5a — exactly one bullet with the optionality marker.
+  ac5a_count=$(printf '%s\n' "$preflight_block" \
+    | grep -F '(Optional, parent-repo / sub-repo layout only)' \
+    | wc -l | tr -d '[:space:]')
+  if [ "$ac5a_count" = "1" ]; then
+    pass "AC5a: PREFLIGHT block has 1 '(Optional, parent-repo / sub-repo layout only)' bullet"
+  else
+    fail "AC5a: expected 1 '(Optional, parent-repo / sub-repo layout only)' bullet, got $ac5a_count"
+  fi
+
+  # AC5b — bullet content mentions patch-apply.
+  ac5b_count=$(printf '%s\n' "$preflight_block" \
+    | grep -F 'tracks an upstream sub-repo via patch-apply' \
+    | wc -l | tr -d '[:space:]')
+  if [ "$ac5b_count" = "1" ]; then
+    pass "AC5b: PREFLIGHT block mentions 'tracks an upstream sub-repo via patch-apply'"
+  else
+    fail "AC5b: expected 1 'tracks an upstream sub-repo via patch-apply' line, got $ac5b_count"
+  fi
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC6 — Regression: every existing test script under tests/ exits 0.
+# Plan §5 Risk 5, §6 AC6.
+# ---------------------------------------------------------------------------
+echo "--- AC6: regression — existing tests/ scripts still exit 0 ---"
+
+# Discover sibling scripts. Exclude this very script to avoid recursion.
+regression_failures=0
+regression_total=0
+for script in "$TESTS_DIR"/*.sh; do
+  [ -f "$script" ] || continue
+  script_name="$(basename "$script")"
+  if [ "$script_name" = "$SELF_NAME" ]; then
+    continue
+  fi
+  regression_total=$((regression_total + 1))
+  rc=0
+  ( cd "$REPO_ROOT" && bash "$script" ) > "/tmp/issue-38-regression-${script_name}.log" 2>&1 || rc=$?
+  if [ "$rc" = "0" ]; then
+    pass "AC6: $script_name exits 0"
+  else
+    fail "AC6: $script_name exited $rc (see /tmp/issue-38-regression-${script_name}.log)"
+    regression_failures=$((regression_failures + 1))
+  fi
+done
+
+if [ "$regression_total" = "0" ]; then
+  fail "AC6: no sibling test scripts found under tests/ — discovery is broken"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# AC7 — Negative: new 0-2b instruction MUST NOT mention .autoflow-state
+# anywhere across the four edited files. Plan §6 AC7, §1 (git-only sub-step),
+# §2.5; phase-a §7.3 (state-tree isolation).
+# ---------------------------------------------------------------------------
+echo "--- AC7: no .autoflow-state writes in the new 0-2b sub-step ---"
+
+# AC7a — automated grep: any line containing `0-2b` across the four files
+# must NOT also contain `.autoflow-state`.
+ac7_violations=$(grep -F '0-2b' \
+  "$CLAUDE_MD" \
+  "$CLAUDE_TEMPLATE" \
+  "$AUTOFLOW_GUIDE" \
+  "$LOCAL_EXAMPLE" \
+  2>/dev/null \
+  | grep -F '.autoflow-state' \
+  | wc -l | tr -d '[:space:]')
+
+if [ "$ac7_violations" = "0" ]; then
+  pass "AC7a: no .autoflow-state references on any 0-2b line across the 4 edited files"
+else
+  fail "AC7a: $ac7_violations lines mention both '0-2b' and '.autoflow-state' (violation)"
+fi
+
+# AC7b — manual review checklist (per delegation.md instruction: encode as
+# documented printf, do NOT automate beyond the grep above).
+printf 'MANUAL: AC7 positive scope — reviewer must confirm the 0-2b step text is git-only (mentions only git or working-tree concepts; no .autoflow-state, no new tooling).\n'
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Inserts a single conditional sub-step `0-2b` into the PREFLIGHT numbered list across `CLAUDE.md`, `CLAUDE.md.template`, and `docs/autoflow-guide.md` so projects using a parent-repo / sub-repo (patch-apply) layout sync the host working tree before branch creation.
- Adds a new **Parent-Repo Sync Procedure** section to `CLAUDE.local.md.example` that back-references PREFLIGHT step `0-2b` as the canonical scheduling site — eliminating the previously free-floating sync procedure.
- Step is positioned strictly between `0-2` and `0-3` so the existing hard-stop rule ("not clean after 0-3") continues to cover any dirty state introduced by `0-2b` without renumbering.

## Approach

Per the DIAGNOSE Phase 3 / GATE:HYPOTHESIS / GATE:PLAN evaluations, the change reuses two pre-existing optional-section carrier patterns rather than inventing new mechanisms:

| File | Carrier | Reason |
|------|---------|--------|
| `CLAUDE.md` (orchestrator manual) | Prose conditional | Orchestrator decides at runtime |
| `CLAUDE.md.template` (user template) | HTML `<!-- BEGIN/END: OPTIONAL PARENT-REPO SYNC -->` block | Removable by users / future init.sh enhancement |
| `docs/autoflow-guide.md` | Prose conditional bullet | Mirrors CLAUDE.md style |

The literal `0-2b.` step text is byte-identical between `CLAUDE.md` and `CLAUDE.md.template` — verified by AC2 in the test suite.

## Test plan

- [x] `tests/test-issue-38-preflight-parent-repo-sync.sh` encodes AC1–AC7 (26 assertions). 25/26 pass after edits.
- [x] AC1 — `0-2b` line appears in `CLAUDE.md` PREFLIGHT block in correct position
- [x] AC2 — `0-2b` line is byte-identical between `CLAUDE.md` and `CLAUDE.md.template`
- [x] AC3 — `CLAUDE.local.md.example` has `### Parent-Repo Sync Procedure` section back-referencing `PREFLIGHT step 0-2b`
- [x] AC4 — HTML carrier present only in template; prose conditional present in `CLAUDE.md`
- [x] AC5 — `docs/autoflow-guide.md` PREFLIGHT Activities includes the optional bullet
- [x] AC6 — 13/14 sibling regression scripts pass (the single failing `tests/test_issue_18_sync.sh` is pre-existing on `main`, out of scope for #38)
- [x] AC7 — no `.autoflow-state/` writes in any `0-2b` instruction

## Auto-Flow evaluation summary

- GATE:HYPOTHESIS: PASS — avg 8.0 (Type 1; structural_overlap 9, code_change 7, structural_change 8)
- GATE:PLAN: PASS — avg 9.0 (all five categories scored 9)
- GATE:QUALITY: PASS — avg 8.8 (correctness 9, quality 9, test_coverage 8, consistency 10, documentation 8)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)