### PR TITLE
feat(#38): PREFLIGHT 0-2b multi sub-repo sync (replaces #48)

### DIFF
--- a/.claude/scripts/preflight-sync
+++ b/.claude/scripts/preflight-sync
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# =============================================================================
+# preflight-sync — PREFLIGHT 0-2b multi sub-repo sync helper
+# =============================================================================
+# Iterates over registered sub-repos, runs `git fetch` per sub-repo, and
+# refuses to start sync when any sub-repo is already dirty (so we never mix
+# pre-existing user state with the upstream sync result).
+#
+# Registry sources (precedence: first match wins):
+#   1. .autoflow/sub-repos.yml   — minimal YAML form:
+#        sub_repos:
+#          - <relative-path>
+#          - <relative-path>
+#   2. .gitmodules               — read submodule paths via `path = ...`
+#
+# If no registry yields any entry, sync is silently skipped (exit 0). This is
+# the "single-repo project" path: nothing to do, do not block PREFLIGHT.
+#
+# Exit codes (sysexits.h-ish):
+#   0   — sync success or registry empty (skip)
+#   65  — registry format error (EX_DATAERR) — yml is present but unparseable
+#   66  — pre-existing dirty sub-repo (sync refused to start)
+#   67  — sync failure mid-run (e.g. git fetch failed)
+#
+# Environment:
+#   SYNC_FORCE=1            — bypass the dirty-sub-repo guard (still runs sync)
+#   CLAUDE_PROJECT_DIR      — host repo root; defaults to $(pwd)
+#
+# Portability: pure bash + grep + awk. No yq, no python, no jq. macOS BSD and
+# Linux GNU userlands both supported (no `sed -i` and no GNU-only flags).
+# =============================================================================
+
+set -uo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+YAML_REGISTRY="${PROJECT_DIR}/.autoflow/sub-repos.yml"
+GITMODULES="${PROJECT_DIR}/.gitmodules"
+
+EX_OK=0
+EX_DATAERR=65
+EX_DIRTY=66
+EX_SYNCFAIL=67
+
+# ---------------------------------------------------------------------------
+# log_err — write a single line to stderr (helper output discoverable by tests)
+# ---------------------------------------------------------------------------
+log_err() {
+  printf '%s\n' "preflight-sync: $*" >&2
+}
+
+# ---------------------------------------------------------------------------
+# log_out — write a single line to stdout (visited sub-repos, skip notice)
+# ---------------------------------------------------------------------------
+log_out() {
+  printf '%s\n' "preflight-sync: $*"
+}
+
+# ---------------------------------------------------------------------------
+# parse_yaml_registry — parse .autoflow/sub-repos.yml
+# Echoes one path per line on stdout, returns:
+#   0 — parsed (may be zero entries — caller treats empty as "fall through")
+#   1 — file does not exist (caller falls through to .gitmodules)
+#   2 — format error (caller maps to exit 65)
+#
+# Recognised form (and ONLY this form):
+#   sub_repos:
+#     - path/one
+#     - path/two
+#
+# Anything else (missing root key, list items not directly under sub_repos,
+# stray punctuation like ':::') is a format error.
+# ---------------------------------------------------------------------------
+parse_yaml_registry() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    return 1
+  fi
+
+  # The first non-blank, non-comment line MUST be exactly `sub_repos:` —
+  # anything else is a format error.
+  local first_line
+  first_line=$(awk '
+    /^[[:space:]]*$/ { next }
+    /^[[:space:]]*#/ { next }
+    { print; exit }
+  ' "$file")
+
+  if [ "$first_line" != "sub_repos:" ]; then
+    return 2
+  fi
+
+  # Walk the remaining lines. Each non-blank, non-comment line after
+  # `sub_repos:` must be a list item ("  - <path>") with two-space indent
+  # (or any leading whitespace followed by `- `). Anything else is a format
+  # error so we do not silently accept partial garbage.
+  local saw_root=0
+  local out=""
+  local line
+  local stripped
+  while IFS= read -r line || [ -n "$line" ]; do
+    # Skip blanks and full-line comments. Trim leading/trailing whitespace via
+    # awk (handles space + tab uniformly across BSD/GNU userlands).
+    stripped="$(printf '%s' "$line" | awk '{$1=$1; print}')"
+    if [ -z "$stripped" ]; then
+      continue
+    fi
+    case "$stripped" in
+      '#'*) continue ;;
+    esac
+
+    if [ "$saw_root" -eq 0 ]; then
+      if [ "$stripped" = "sub_repos:" ]; then
+        saw_root=1
+        continue
+      else
+        # Should be unreachable since first_line check passed, but stay safe.
+        return 2
+      fi
+    fi
+
+    # Must be a list item starting with `- `
+    case "$stripped" in
+      '- '*)
+        local item="${stripped#- }"
+        # Trim trailing whitespace; reject empty or quoted-with-colons forms.
+        item="$(printf '%s' "$item" | awk '{$1=$1; print}')"
+        if [ -z "$item" ]; then
+          return 2
+        fi
+        # Reject items containing ':' or other YAML structure markers — we
+        # only accept plain scalars.
+        case "$item" in
+          *:*|*'['*|*']'*|*'{'*|*'}'*) return 2 ;;
+        esac
+        out="${out}${item}"$'\n'
+        ;;
+      *)
+        return 2
+        ;;
+    esac
+  done < "$file"
+
+  if [ "$saw_root" -eq 0 ]; then
+    return 2
+  fi
+
+  printf '%s' "$out"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# parse_gitmodules — extract `path = ...` values from .gitmodules
+# Echoes one path per line on stdout. Returns 0 always (empty stdout means
+# no submodules registered).
+# ---------------------------------------------------------------------------
+parse_gitmodules() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    return 0
+  fi
+  awk '
+    /^[[:space:]]*path[[:space:]]*=/ {
+      sub(/^[[:space:]]*path[[:space:]]*=[[:space:]]*/, "")
+      sub(/[[:space:]]+$/, "")
+      if (length($0) > 0) print
+    }
+  ' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# load_registry — populate REGISTRY_ENTRIES (newline-separated paths)
+# Sets REGISTRY_SOURCE to "yaml" | "gitmodules" | "none" for diagnostics.
+# Exits 65 on yaml format error.
+# ---------------------------------------------------------------------------
+REGISTRY_ENTRIES=""
+REGISTRY_SOURCE="none"
+
+load_registry() {
+  if [ -f "$YAML_REGISTRY" ]; then
+    local parsed rc
+    parsed=$(parse_yaml_registry "$YAML_REGISTRY")
+    rc=$?
+    if [ "$rc" -eq 2 ]; then
+      log_err "registry format error in .autoflow/sub-repos.yml — expected 'sub_repos:' root key with '- <path>' list items"
+      exit "$EX_DATAERR"
+    fi
+    if [ "$rc" -eq 0 ]; then
+      REGISTRY_ENTRIES="$parsed"
+      REGISTRY_SOURCE="yaml"
+      return 0
+    fi
+    # rc == 1 → file missing race; fall through.
+  fi
+
+  if [ -f "$GITMODULES" ]; then
+    REGISTRY_ENTRIES="$(parse_gitmodules "$GITMODULES")"
+    REGISTRY_SOURCE="gitmodules"
+    return 0
+  fi
+
+  REGISTRY_ENTRIES=""
+  REGISTRY_SOURCE="none"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# is_dirty — return 0 if the given sub-repo working tree is dirty
+# Treats both modified-tracked and untracked files as dirty.
+# Non-git directories are considered "not dirty" (handled by sync step).
+# ---------------------------------------------------------------------------
+is_dirty() {
+  local sub="$1"
+  if [ ! -d "$sub/.git" ] && [ ! -f "$sub/.git" ]; then
+    return 1
+  fi
+  local status
+  status=$(git -C "$sub" status --porcelain 2>/dev/null || true)
+  if [ -n "$status" ]; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# sync_one — fetch a single sub-repo. Returns 0 on success, non-zero on
+# fetch failure. Output is captured and surfaced in the helper's stderr so
+# the caller sees what went wrong.
+# ---------------------------------------------------------------------------
+sync_one() {
+  local sub="$1"
+  log_out "syncing ${sub}"
+  if [ ! -d "$sub/.git" ] && [ ! -f "$sub/.git" ]; then
+    # Not a git working tree — nothing to fetch. Treat as success so single
+    # plain-directory sub-repos do not block PREFLIGHT.
+    return 0
+  fi
+  local fetch_out
+  if ! fetch_out=$(git -C "$sub" fetch --quiet 2>&1); then
+    log_err "fetch failed for ${sub}: ${fetch_out}"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+  load_registry
+
+  # Filter empty lines from REGISTRY_ENTRIES into a real array.
+  local entries=()
+  local line
+  while IFS= read -r line; do
+    [ -n "$line" ] && entries+=("$line")
+  done <<EOF
+$REGISTRY_ENTRIES
+EOF
+
+  if [ "${#entries[@]}" -eq 0 ]; then
+    log_out "registry empty — skipped (no sub-repos to sync)"
+    exit "$EX_OK"
+  fi
+
+  log_out "registry source: ${REGISTRY_SOURCE}"
+
+  # ---- Pre-flight dirty guard ----
+  # Identify pre-existing dirty sub-repos. If any are dirty and SYNC_FORCE is
+  # not set, refuse to start sync so the user does not mix unsaved work with
+  # an upstream fetch result.
+  local dirty=()
+  local sub
+  for sub in "${entries[@]}"; do
+    if is_dirty "${PROJECT_DIR}/${sub}"; then
+      dirty+=("$sub")
+    fi
+  done
+
+  if [ "${#dirty[@]}" -gt 0 ]; then
+    if [ -z "${SYNC_FORCE:-}" ]; then
+      log_err "pre-existing dirty sub-repos (refusing sync; set SYNC_FORCE=1 to override):"
+      for sub in "${dirty[@]}"; do
+        log_err "  - ${sub}"
+      done
+      exit "$EX_DIRTY"
+    else
+      log_out "SYNC_FORCE=1 — bypassing dirty guard for: ${dirty[*]}"
+    fi
+  fi
+
+  # ---- Sync pass ----
+  local any_fail=0
+  for sub in "${entries[@]}"; do
+    if ! sync_one "${PROJECT_DIR}/${sub}"; then
+      any_fail=1
+    fi
+  done
+
+  if [ "$any_fail" -ne 0 ]; then
+    log_err "one or more sub-repos failed to sync"
+    exit "$EX_SYNCFAIL"
+  fi
+
+  log_out "sync complete (${#entries[@]} sub-repos)"
+  exit "$EX_OK"
+}
+
+main "$@"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,17 @@ LAND:            Merge & Close     → Human approves and merges
 ```
 0-1. git status — no uncommitted changes, no untracked files in working area
 0-2. git fetch origin — sync with remote
+0-2b. [CONDITIONAL: multi-repo projects only] Multi sub-repo sync —
+      run `.claude/scripts/preflight-sync` to fetch and verify each registered
+      sub-repo. Registry source: `.autoflow/sub-repos.yml` (preferred) or
+      `.gitmodules` (fallback). Auto-skipped (exit 0) when both registries are
+      empty — single-repo projects pay no cost.
+      Exit codes: 0 success/skip, 65 registry format error, 66 pre-existing
+      dirty sub-repo (refusing sync), 67 sync mid-run failure. SYNC_FORCE=1
+      bypasses the dirty guard for testing/CI.
+      On exit 67, PREFLIGHT aborts and DIAGNOSE must NOT begin.
+      See [docs/design-rationale.md > Decision 12](docs/design-rationale.md#decision-12-multi-sub-repo-sync-uses-git-submodule-foreach-pattern)
+      for why this skip is consistent with 'Never skip phases'.
 0-3. Resolve any dirty state (stash, commit, or discard with user approval)
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```

--- a/CLAUDE.md.template
+++ b/CLAUDE.md.template
@@ -84,6 +84,17 @@ Auto-Flow is a structured development lifecycle that ensures quality through eva
 ```
 0-1. git status — no uncommitted changes, no untracked files in working area
 0-2. git fetch origin — sync with remote
+0-2b. [CONDITIONAL: multi-repo projects only] Multi sub-repo sync —
+      run `.claude/scripts/preflight-sync` to fetch and verify each registered
+      sub-repo. Registry source: `.autoflow/sub-repos.yml` (preferred) or
+      `.gitmodules` (fallback). Auto-skipped (exit 0) when both registries are
+      empty — single-repo projects pay no cost.
+      Exit codes: 0 success/skip, 65 registry format error, 66 pre-existing
+      dirty sub-repo (refusing sync), 67 sync mid-run failure. SYNC_FORCE=1
+      bypasses the dirty guard for testing/CI.
+      On exit 67, PREFLIGHT aborts and DIAGNOSE must NOT begin.
+      See [docs/design-rationale.md > Decision 12](docs/design-rationale.md#decision-12-multi-sub-repo-sync-uses-git-submodule-foreach-pattern)
+      for why this skip is consistent with 'Never skip phases'.
 0-3. Resolve any dirty state (stash, commit, or discard with user approval)
 0-4. git checkout -b <branch-type>/<issue>-<desc> main
 ```

--- a/docs/autoflow-guide.md
+++ b/docs/autoflow-guide.md
@@ -21,19 +21,39 @@ The key principles:
 **Goal**: Ensure a clean Git state before any analysis or coding begins.
 
 ### Activities
-- `git status` — verify no uncommitted changes or untracked files in working area
-- `git fetch origin` — sync with remote
-- Resolve any dirty state (stash, commit, or discard with user approval)
-- `git checkout -b <branch-type>/<issue>-<desc> main` — create feature branch from latest main
+
+| Sub-step | Action | Notes |
+|---------|--------|-------|
+| 0-1 | `git status` — verify no uncommitted changes or untracked files in working area | Host repo only |
+| 0-2 | `git fetch origin` — sync with remote | Host repo only |
+| 0-2b | **[CONDITIONAL: multi-repo projects only]** Multi sub-repo sync — run `.claude/scripts/preflight-sync` | Auto-skipped when no registry exists. See "Multi sub-repo sync" below. |
+| 0-3 | Resolve any dirty state (stash, commit, or discard with user approval) | |
+| 0-4 | `git checkout -b <branch-type>/<issue>-<desc> main` — create feature branch from latest main | |
+
+### Multi sub-repo sync (0-2b)
+
+The 0-2b sub-step iterates registered sub-repos via the `.claude/scripts/preflight-sync` helper. The helper reads `.autoflow/sub-repos.yml` first; if absent, it falls back to `.gitmodules`. When neither registry yields an entry, the sub-step exits 0 (skip) — single-repo projects pay no cost. This skip is an **objective precondition skip**, not a biased "this one is simple" judgment, and is therefore consistent with Execution Principle 1 ("Never skip phases"). See [design-rationale.md > Decision 12](design-rationale.md#decision-12-multi-sub-repo-sync-uses-git-submodule-foreach-pattern).
+
+Helper exit codes:
+
+| Code | Meaning | PREFLIGHT effect |
+|------|---------|------------------|
+| 0 | Sync success or registry empty | Continue to 0-3 |
+| 65 | Registry format error (`.autoflow/sub-repos.yml` malformed) | Abort PREFLIGHT — fix registry |
+| 66 | Pre-existing dirty sub-repo (sync refused) | Abort PREFLIGHT — clean sub-repos or set `SYNC_FORCE=1` |
+| 67 | Sync mid-run failure (e.g. `git fetch` failed) | Abort PREFLIGHT — DIAGNOSE must NOT begin |
+
+`SYNC_FORCE=1` is an escape hatch that bypasses the dirty-guard (exit 66 path). It does NOT bypass exit 65 or 67.
 
 ### Exit Criteria
-- Git working tree is clean
+- Git working tree is clean (host repo)
+- 0-2b: all registered sub-repos are clean and at the recorded pointer (or no registry exists → skip)
 - Branch created from latest main
 - `intake.md` created at `.autoflow-state/<sub-repo-id>/<issue-number>/intake.md` recording the sub-repo identifier, branch, and host state location (see [design-rationale.md > Decision 10](design-rationale.md#decision-10-state-tree-is-namespaced-by-sub-repo-identifier))
 - Ready for DIAGNOSE analysis
 
 ### Hard Stop Rule
-If Git state is not clean after resolution attempts, **stop and report to user**. Do NOT proceed to DIAGNOSE. Starting work on a dirty Git state causes merge conflicts, lost changes, and broken state downstream.
+If Git state is not clean after resolution attempts, **stop and report to user**. Do NOT proceed to DIAGNOSE. Starting work on a dirty Git state causes merge conflicts, lost changes, and broken state downstream. The same applies if `preflight-sync` exits non-zero at 0-2b — the orchestrator must NOT advance the phase to DIAGNOSE.
 
 ### intake.md Format
 

--- a/docs/design-rationale.md
+++ b/docs/design-rationale.md
@@ -244,6 +244,39 @@ The host repo is the only writeable home for `.autoflow-state/`. A sub-repo cont
 
 ---
 
+### Decision 12: Multi sub-repo sync uses `git submodule foreach` pattern
+
+**What it does**
+
+PREFLIGHT carries a sub-step `0-2b` that iterates all registered sub-repos and runs `git fetch` per sub-repo through a small helper, `.claude/scripts/preflight-sync`. The helper reads `.autoflow/sub-repos.yml` first (a minimal `sub_repos:` list of relative paths) and falls back to `.gitmodules` (`path = ...` lines) when the YAML registry is absent. When neither registry yields any entry, the sub-step exits 0 with a "skipped" notice and PREFLIGHT continues. The helper exits 65 on registry format error, 66 when any sub-repo is already dirty (refusing to start sync), and 67 when a `git fetch` fails mid-run. The marker `[CONDITIONAL: multi-repo projects only]` is attached to 0-2b in CLAUDE.md, CLAUDE.md.template, and docs/autoflow-guide.md to signal to readers that the sub-step is structurally optional. The escape hatch `SYNC_FORCE=1` bypasses only the exit-66 dirty guard (testing/CI).
+
+**Why it works this way**
+
+The reference deployment (ontology-platform) already runs an in-house `git submodule foreach` loop to fetch every sub-repo before issue analysis begins. Generalising that pattern as a small helper keeps the mechanism readable and dependency-free (pure bash + grep + awk — no `yq`, no Python). Choosing `.autoflow/sub-repos.yml` as the preferred registry lets users register plain directory paths that are not git submodules (monorepo subdirs, vendored trees), while `.gitmodules` fallback keeps the zero-configuration path working for projects that already use submodules. Splitting the failure modes across distinct exit codes (65/66/67) lets the orchestrator and gate hook react differently — 65 demands a registry fix, 66 lets the user choose between cleaning up or `SYNC_FORCE=1`, 67 is an upstream/network problem that requires retry. Refusing to start sync when any sub-repo is already dirty is the same Git Clean Check discipline applied at the sub-repo level — partial sync mixed with unsaved local edits is the failure mode we explicitly avoid.
+
+**`[CONDITIONAL]` marker and the relationship with "Never skip phases"**
+
+Execution Principle 1 in CLAUDE.md states "Never skip phases — every phase is executed in order." The marker `[CONDITIONAL: multi-repo projects only]` does not contradict this principle, and the distinction is load-bearing:
+
+- **Forbidden**: skipping a phase based on a *judgment* about complexity or risk ("this one is simple, we can drop GATE:QUALITY"). That judgment is itself a bias, which the pipeline exists to neutralise.
+- **Permitted**: a sub-step whose execution is gated by an *objective precondition* whose absence makes the sub-step a no-op. 0-2b runs in every PREFLIGHT; the helper is invoked unconditionally and exits 0 with a "skipped" notice when no registry yields any entry. There is no human or AI deciding "we don't need this today" — the helper inspects the filesystem and the registry tells it whether work exists.
+
+The `[CONDITIONAL]` marker exists so a human reader (and, downstream, an Evaluation AI) can see at a glance that a sub-step is structurally optional by registry, not by discretion. A sub-step without the marker is mandatory regardless of project topology.
+
+**Rejected alternatives**
+
+- **Maintain a separate `last-sync` metadata file per sub-repo.** Rejected because the submodule pointer recorded by the parent repo already represents "the last commit the parent acknowledged," which is the same information last-sync would track. Adding a parallel store creates two sources of truth that can diverge. ontology-platform's working pattern relies entirely on the submodule pointer.
+- **Use `yq`/`python` to parse `.autoflow/sub-repos.yml`.** Rejected because PREFLIGHT runs before any project-level dependency setup; requiring an external parser adds an installation barrier that breaks `init.sh`-and-go adoption. The minimal `sub_repos: <list>` form is parseable by `awk`+`bash` in well under 100 lines.
+- **Treat sub-repos like first-class phases (a separate "sub-repo PREFLIGHT" phase).** Rejected because the per-sub-repo work is bounded and uniform (fetch + clean check); promoting it to a phase would force the gate hook and `phase-set` to track per-sub-repo state, which is wildly disproportionate to the actual coupling.
+- **Drop the dirty-guard and let sync proceed regardless.** Rejected because sync failure mid-run on a dirty sub-repo leaves a state where the user cannot tell which changes are theirs and which arrived from upstream. The exit 66 path forces the user to make the choice explicitly, with `SYNC_FORCE=1` available when they really mean it.
+- **Single combined exit code on any sync error.** Rejected because the orchestrator's response differs by failure mode — 65 is "configuration error, retry impossible without edit," 66 is "user-recoverable, opt-in override exists," 67 is "transient or upstream, retry may help." Collapsing them removes the orchestrator's ability to act sensibly.
+
+**What this means**
+
+A single-repo project sees no behaviour change at all — `preflight-sync` finds no registry, prints a "skipped" line, and PREFLIGHT continues. A multi-repo project gets a uniform fetch-and-validate pass at the start of every issue, with three distinct failure modes whose exit codes the orchestrator already knows how to interpret. The `[CONDITIONAL]` marker formalises the language we use when a sub-step is structurally optional, so future additions of similar sub-steps can reuse the same convention without revisiting the "Never skip phases" debate each time.
+
+---
+
 ## Evaluation System Design Intent
 
 ### Why Scoring Criteria Are Not Fixed

--- a/subrepo-templates/_common/CLAUDE.md.template
+++ b/subrepo-templates/_common/CLAUDE.md.template
@@ -20,7 +20,13 @@
 This repository follows the Auto-Flow lifecycle defined in:
 **`{{GITHUB_ORG}}/{{REPO_ORCHESTRATOR}}/CLAUDE.md`**
 
-All STEPs (0–9), evaluation criteria, and gate rules from the orchestrator apply here.
+All phases (PREFLIGHT → LAND), evaluation criteria, and gate rules from the orchestrator apply here.
+
+### Parent-repo sync timing
+
+This sub-repo is fetched and clean-checked by the parent (orchestrator) repo at **PREFLIGHT sub-step 0-2b** via `.claude/scripts/preflight-sync`. That sub-step carries the `[CONDITIONAL: multi-repo projects only]` marker and is the single, well-defined point where parent → sub-repo synchronisation happens during an Auto-Flow run. There is no free-floating "sync whenever" rule in this sub-repo — if the parent is at PREFLIGHT, the parent's helper drives the sync; otherwise this sub-repo does not initiate parent-side sync on its own.
+
+If the parent's `preflight-sync` reports this sub-repo as dirty (exit 66), commit or stash the working tree before re-running; if it reports a fetch failure (exit 67), check the upstream URL and retry. See [docs/design-rationale.md > Decision 12](../../docs/design-rationale.md) in the orchestrator repo for the full rationale.
 
 ---
 

--- a/tests/test-issue-38-multi-subrepo-sync.sh
+++ b/tests/test-issue-38-multi-subrepo-sync.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: Issue #38 — multi sub-repo sync integration
+# =============================================================================
+# Validates the document/state integration of PREFLIGHT 0-2b:
+#   TC9  — When preflight-sync exits 67 during PREFLIGHT, phase-set must NOT
+#          allow transition to DIAGNOSE (PREFLIGHT abort propagates).
+#   TC10 — CLAUDE.md and CLAUDE.md.template both define the `0-2b` sub-step.
+#   TC11 — docs/autoflow-guide.md PREFLIGHT section table contains a `0-2b` row.
+#   TC12 — docs/design-rationale.md contains a `[CONDITIONAL]` marker AND
+#          relates the new Decision to "Never skip phases".
+#
+# These tests must FAIL until the Developer AI lands the implementation —
+# they assert the end-state contract.
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PREFLIGHT_SYNC="${REPO_ROOT}/.claude/scripts/preflight-sync"
+PHASE_SET="${REPO_ROOT}/.claude/scripts/phase-set"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+CLAUDE_TEMPLATE="${REPO_ROOT}/CLAUDE.md.template"
+GUIDE="${REPO_ROOT}/docs/autoflow-guide.md"
+RATIONALE="${REPO_ROOT}/docs/design-rationale.md"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+assert_exit_code() {
+  local expected="$1" actual="$2" desc="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (expected exit $expected, got $actual)")
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+  fi
+}
+
+assert_file_contains() {
+  # Uses grep -F so that bracketed/regex-special patterns like '[CONDITIONAL]'
+  # are matched as literal strings (not character classes).
+  local file="$1" pattern="$2" desc="$3"
+  if [ -f "$file" ] && grep -qF -- "$pattern" "$file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (pattern '$pattern' not found in $file)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+assert_file_matches_regex() {
+  local file="$1" regex="$2" desc="$3"
+  if [ -f "$file" ] && grep -Eq -- "$regex" "$file" 2>/dev/null; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (regex '$regex' did not match in $file)")
+    echo "  FAIL: $desc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers (TC9)
+# ---------------------------------------------------------------------------
+TEST_DIR=""
+
+setup_test_dir() {
+  TEST_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'issue-38-int')
+  TEST_DIR="$(cd "$TEST_DIR" && pwd)"
+}
+
+cleanup_test_dir() {
+  if [ -n "${TEST_DIR:-}" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+  TEST_DIR=""
+}
+
+trap 'cleanup_test_dir' EXIT
+
+echo "=== Test Suite: Issue #38 multi sub-repo sync (integration) ==="
+echo ""
+
+# ===========================================================================
+# TC9: PREFLIGHT abort integration —
+# When `.autoflow-state/<issue>/phase` is PREFLIGHT and preflight-sync would
+# fail (exit 67), phase-set must not silently advance to DIAGNOSE.
+#
+# Strategy: invoke preflight-sync on a fixture rigged to exit 67 (broken
+# origin URL). Whatever exit code we observe, then attempt the DIAGNOSE
+# transition only if sync exited 0 (orchestrator contract). The test passes
+# ONLY when both:
+#   (a) sync exited exactly 67, AND
+#   (b) phase file remained at PREFLIGHT.
+# Both halves must hold; we do NOT credit "phase unchanged" when sync itself
+# couldn't even run (e.g. helper missing → exit 127), because that would
+# trivially pass without proving the abort contract.
+# ===========================================================================
+echo "--- TC9: PREFLIGHT abort blocks DIAGNOSE transition ---"
+setup_test_dir
+# Build a mock parent + sub-repo with broken origin so sync fails.
+( cd "$TEST_DIR" \
+    && git init -q . \
+    && git config user.email "test@example.com" \
+    && git config user.name "Test User" \
+    && git commit --allow-empty -q -m "init" )
+mkdir -p "${TEST_DIR}/subA"
+( cd "${TEST_DIR}/subA" \
+    && git init -q . \
+    && git config user.email "sub@example.com" \
+    && git config user.name "Sub User" \
+    && echo "x" > seed.txt \
+    && git add seed.txt \
+    && git commit -q -m "seed" \
+    && git remote add origin "/nonexistent/broken/path.git" )
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subA
+EOF
+# State setup: current-issue=38, phase=PREFLIGHT (the gate).
+mkdir -p "${TEST_DIR}/.autoflow-state/38"
+echo "38" > "${TEST_DIR}/.autoflow-state/current-issue"
+echo "PREFLIGHT" > "${TEST_DIR}/.autoflow-state/38/phase"
+
+# Run preflight-sync; capture its exit code.
+sync_exit=0
+( cd "$TEST_DIR" \
+    && bash "$PREFLIGHT_SYNC" \
+      > "${TEST_DIR}/sync.out" 2> "${TEST_DIR}/sync.err" ) \
+  || sync_exit=$?
+assert_exit_code 67 "$sync_exit" \
+  "TC9a: preflight-sync against broken sub-repo exits 67"
+
+# Orchestrator contract: only invoke phase-set when sync_exit == 0. We model
+# this by SKIPPING the phase-set call when sync_exit is non-zero. Then the
+# end-state assertion is "phase file is still PREFLIGHT".
+if [ "$sync_exit" -eq 0 ]; then
+  # In this test sync MUST have failed; if it succeeds we let phase-set try
+  # so the test surfaces the broken contract.
+  CLAUDE_PROJECT_DIR="$TEST_DIR" bash "$PHASE_SET" DIAGNOSE \
+    > "${TEST_DIR}/ps.out" 2> "${TEST_DIR}/ps.err" || true
+fi
+
+actual_phase=""
+if [ -f "${TEST_DIR}/.autoflow-state/38/phase" ]; then
+  actual_phase=$(tr -d '[:space:]' < "${TEST_DIR}/.autoflow-state/38/phase")
+fi
+# TC9b passes ONLY if sync_exit was exactly 67 AND phase is still PREFLIGHT.
+# Either condition alone (e.g. helper missing → 127, or wrong exit code) is
+# a contract violation and must FAIL — this prevents TC9b from passing
+# trivially when the implementation is absent.
+if [ "$sync_exit" -eq 67 ] && [ "$actual_phase" = "PREFLIGHT" ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC9b: sync exit 67 AND phase remained PREFLIGHT (abort contract)"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC9b: abort contract not satisfied (sync_exit=$sync_exit, phase='$actual_phase')")
+  echo "  FAIL: TC9b: abort contract not satisfied (sync_exit=$sync_exit, phase='$actual_phase')"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC10: CLAUDE.md and CLAUDE.md.template both reference 0-2b
+# ===========================================================================
+echo "--- TC10: CLAUDE.md / CLAUDE.md.template both define 0-2b ---"
+assert_file_matches_regex "$CLAUDE_MD" "0-2b" \
+  "TC10a: CLAUDE.md references the 0-2b sub-step"
+assert_file_matches_regex "$CLAUDE_TEMPLATE" "0-2b" \
+  "TC10b: CLAUDE.md.template references the 0-2b sub-step"
+echo ""
+
+# ===========================================================================
+# TC11: docs/autoflow-guide.md has a 0-2b row in the PREFLIGHT section table.
+# We require the row to appear AFTER the PREFLIGHT section heading. Use awk
+# to slice the file from "## PREFLIGHT" to the next "## " heading and grep
+# inside that slice. If no slice is produced or no match is found, FAIL.
+# ===========================================================================
+echo "--- TC11: autoflow-guide.md PREFLIGHT table contains 0-2b row ---"
+if [ -f "$GUIDE" ]; then
+  preflight_slice=$(awk '
+    /^## .*PREFLIGHT/ { in_section=1; print; next }
+    /^## / && in_section { in_section=0 }
+    in_section { print }
+  ' "$GUIDE")
+  if printf '%s\n' "$preflight_slice" | grep -Eq "0-2b"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: TC11: autoflow-guide.md PREFLIGHT section contains 0-2b"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: TC11: autoflow-guide.md PREFLIGHT section missing 0-2b row")
+    echo "  FAIL: TC11: autoflow-guide.md PREFLIGHT section missing 0-2b row"
+  fi
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC11: docs/autoflow-guide.md does not exist")
+  echo "  FAIL: TC11: docs/autoflow-guide.md does not exist"
+fi
+echo ""
+
+# ===========================================================================
+# TC12: design-rationale.md contains the [CONDITIONAL] marker AND relates the
+# new Decision to "Never skip phases".
+# Uses grep -F so the literal [CONDITIONAL] token is matched (not parsed as
+# a character class).
+# ===========================================================================
+echo "--- TC12: design-rationale.md has [CONDITIONAL] marker + 'Never skip phases' tie ---"
+assert_file_contains "$RATIONALE" "[CONDITIONAL]" \
+  "TC12a: design-rationale.md contains literal '[CONDITIONAL]' marker"
+assert_file_contains "$RATIONALE" "Never skip phases" \
+  "TC12b: design-rationale.md references 'Never skip phases'"
+echo ""
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi

--- a/tests/test-preflight-sync.sh
+++ b/tests/test-preflight-sync.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Suite: PREFLIGHT multi sub-repo sync helper (Issue #38, unit tests)
+# =============================================================================
+# Validates that .claude/scripts/preflight-sync:
+#   - Skips silently (exit 0) when no registry exists (TC1)
+#   - Rejects malformed YAML registry with EX_DATAERR=65 (TC2)
+#   - Iterates over registered sub-repos and reports clean state (TC3)
+#   - Detects pre-existing dirty state and aborts with exit 66 (TC4)
+#   - Surfaces fetch failures during sync as exit 67 (TC5)
+#   - Honours SYNC_FORCE=1 to bypass dirty-state guard (TC6)
+#   - Falls back to .gitmodules when .autoflow/sub-repos.yml is absent (TC7)
+#   - Prefers .autoflow/sub-repos.yml when both registries exist (TC8)
+#
+# All test cases set up an isolated mktemp working directory, treat it as the
+# parent repo, and clean up via trap. The helper is invoked via `bash` so it
+# does not need to be executable on disk to run (matches phase-set test style).
+#
+# Exit codes the helper is expected to use:
+#   0  — sync success or skip (registry empty)
+#   65 — registry format error (EX_DATAERR)
+#   66 — pre-existing dirty state in a sub-repo
+#   67 — sync failure (e.g. git fetch failed)
+# =============================================================================
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PREFLIGHT_SYNC="${REPO_ROOT}/.claude/scripts/preflight-sync"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Test helpers (style mirrors tests/test-phase-set.sh)
+# ---------------------------------------------------------------------------
+assert_exit_code() {
+  local expected="$1" actual="$2" desc="$3"
+  if [ "$actual" -eq "$expected" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("FAIL: $desc (expected exit $expected, got $actual)")
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+TEST_DIR=""
+
+setup_test_dir() {
+  TEST_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'preflight-sync')
+  # macOS mktemp returns /var/folders/... which is fine; record absolute path
+  TEST_DIR="$(cd "$TEST_DIR" && pwd)"
+}
+
+cleanup_test_dir() {
+  if [ -n "${TEST_DIR:-}" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+  TEST_DIR=""
+}
+
+# Always clean up on script exit (covers any unexpected interruption between
+# explicit cleanup_test_dir calls).
+trap 'cleanup_test_dir' EXIT
+
+# Initialize TEST_DIR as a parent git repo (so 'git submodule foreach' style
+# helpers do not blow up on missing .git).
+init_parent_repo() {
+  ( cd "$TEST_DIR" \
+      && git init -q . \
+      && git config user.email "test@example.com" \
+      && git config user.name "Test User" \
+      && git commit --allow-empty -q -m "init" )
+}
+
+# Create a mock sub-repo directory at $TEST_DIR/$1 with one commit.
+init_sub_repo() {
+  local name="$1"
+  local sub_path="${TEST_DIR}/${name}"
+  mkdir -p "$sub_path"
+  ( cd "$sub_path" \
+      && git init -q . \
+      && git config user.email "sub@example.com" \
+      && git config user.name "Sub User" \
+      && echo "x" > seed.txt \
+      && git add seed.txt \
+      && git commit -q -m "seed" )
+  # Add a fake "origin" remote pointing at itself so fetch is harmless and
+  # exists. Tests that need fetch to fail will overwrite the URL.
+  ( cd "$sub_path" \
+      && git remote add origin "$sub_path" 2>/dev/null || true )
+}
+
+# Run the helper from inside TEST_DIR; capture stdout/stderr/exit code.
+run_preflight_sync() {
+  local exit_code=0
+  ( cd "$TEST_DIR" \
+      && bash "$PREFLIGHT_SYNC" "$@" \
+        > "${TEST_DIR}/stdout.txt" 2> "${TEST_DIR}/stderr.txt" ) \
+    || exit_code=$?
+  echo "$exit_code"
+}
+
+echo "=== Test Suite: preflight-sync helper (Issue #38 — unit) ==="
+echo ""
+
+# ===========================================================================
+# TC1: registry empty → exit 0, stdout mentions "skipped"
+# ===========================================================================
+echo "--- TC1: no registry → skip with exit 0 ---"
+setup_test_dir
+init_parent_repo
+# Deliberately: no .gitmodules, no .autoflow/sub-repos.yml
+exit_code=$(run_preflight_sync)
+assert_exit_code 0 "$exit_code" \
+  "TC1a: empty registry exits 0"
+if [ -f "${TEST_DIR}/stdout.txt" ] \
+    && grep -qi "skip" "${TEST_DIR}/stdout.txt" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC1b: stdout contains 'skip' keyword"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC1b: stdout does not contain 'skip' keyword")
+  echo "  FAIL: TC1b: stdout does not contain 'skip' keyword"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC2: malformed YAML in .autoflow/sub-repos.yml → exit 65 (EX_DATAERR)
+# ===========================================================================
+echo "--- TC2: malformed registry YAML → exit 65 ---"
+setup_test_dir
+init_parent_repo
+mkdir -p "${TEST_DIR}/.autoflow"
+# Garbage that does NOT start with the expected `sub_repos:` root key, with
+# stray punctuation that any sane parser must reject.
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+this is: [not, valid
+  - oops
+   ::: broken :::
+EOF
+exit_code=$(run_preflight_sync)
+assert_exit_code 65 "$exit_code" \
+  "TC2a: malformed YAML registry exits 65"
+# stderr should mention the file or 'format' so the user knows what failed.
+if grep -Eqi "sub-repos\.yml|format|invalid|parse" "${TEST_DIR}/stderr.txt" \
+      2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC2b: stderr explains the registry format error"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC2b: stderr lacks a clear format-error message")
+  echo "  FAIL: TC2b: stderr lacks a clear format-error message"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC3: registered clean sub-repos → exit 0, both sub-repo names referenced
+# ===========================================================================
+echo "--- TC3: clean sub-repos sync → exit 0, both names visible ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subA"
+init_sub_repo "subB"
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subA
+  - subB
+EOF
+exit_code=$(run_preflight_sync)
+assert_exit_code 0 "$exit_code" \
+  "TC3a: clean registered sub-repos exit 0"
+# Combined output (stdout+stderr) should reference both sub-repos so the user
+# sees what was visited. The helper may use either stream; check both.
+combined="${TEST_DIR}/combined.txt"
+cat "${TEST_DIR}/stdout.txt" "${TEST_DIR}/stderr.txt" > "$combined" 2>/dev/null
+if grep -q "subA" "$combined" 2>/dev/null \
+    && grep -q "subB" "$combined" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC3b: helper output references both subA and subB"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC3b: helper output missing subA and/or subB references")
+  echo "  FAIL: TC3b: helper output missing subA and/or subB references"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC4: pre-existing dirty in one sub-repo → exit 66, name reported
+# ===========================================================================
+echo "--- TC4: dirty sub-repo pre-check → exit 66, name reported ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subA"
+init_sub_repo "subB"
+# Make subB dirty by adding an untracked file.
+echo "untracked" > "${TEST_DIR}/subB/dirty.txt"
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subA
+  - subB
+EOF
+exit_code=$(run_preflight_sync)
+assert_exit_code 66 "$exit_code" \
+  "TC4a: pre-existing dirty exits 66"
+combined="${TEST_DIR}/combined.txt"
+cat "${TEST_DIR}/stdout.txt" "${TEST_DIR}/stderr.txt" > "$combined" 2>/dev/null
+if grep -q "subB" "$combined" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC4b: dirty sub-repo name (subB) is reported"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC4b: dirty sub-repo name (subB) NOT reported in output")
+  echo "  FAIL: TC4b: dirty sub-repo name (subB) NOT reported in output"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC5: fetch failure during sync → exit 67
+# ===========================================================================
+echo "--- TC5: fetch failure during sync → exit 67 ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subA"
+# Break the origin URL so `git fetch` will fail unconditionally.
+( cd "${TEST_DIR}/subA" \
+    && git remote remove origin 2>/dev/null || true
+  cd "${TEST_DIR}/subA" \
+    && git remote add origin "/nonexistent/path/that/does/not/exist.git" )
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subA
+EOF
+exit_code=$(run_preflight_sync)
+assert_exit_code 67 "$exit_code" \
+  "TC5a: fetch failure exits 67"
+combined="${TEST_DIR}/combined.txt"
+cat "${TEST_DIR}/stdout.txt" "${TEST_DIR}/stderr.txt" > "$combined" 2>/dev/null
+if grep -Eqi "fetch|sync.*fail|failed" "$combined" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC5b: helper output mentions the fetch/sync failure"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC5b: helper output does not mention the failure")
+  echo "  FAIL: TC5b: helper output does not mention the failure"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC6: SYNC_FORCE=1 bypasses the dirty-state guard from TC4
+# ===========================================================================
+echo "--- TC6: SYNC_FORCE=1 bypasses dirty guard → exit 0 ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subA"
+init_sub_repo "subB"
+echo "untracked" > "${TEST_DIR}/subB/dirty.txt"
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subA
+  - subB
+EOF
+exit_code=0
+( cd "$TEST_DIR" \
+    && SYNC_FORCE=1 bash "$PREFLIGHT_SYNC" \
+      > "${TEST_DIR}/stdout.txt" 2> "${TEST_DIR}/stderr.txt" ) \
+  || exit_code=$?
+assert_exit_code 0 "$exit_code" \
+  "TC6: SYNC_FORCE=1 with dirty sub-repo exits 0 (guard bypassed)"
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC7: .gitmodules fallback (no .autoflow/sub-repos.yml) → exit 0
+# ===========================================================================
+echo "--- TC7: .gitmodules fallback when yml absent → exit 0 ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subA"
+# Write a minimal .gitmodules listing subA (we do not actually run
+# `git submodule add` because we want a controlled fixture without network).
+cat > "${TEST_DIR}/.gitmodules" <<'EOF'
+[submodule "subA"]
+	path = subA
+	url = ./subA
+EOF
+# Deliberately: NO .autoflow/sub-repos.yml
+exit_code=$(run_preflight_sync)
+assert_exit_code 0 "$exit_code" \
+  "TC7a: .gitmodules-only registry exits 0"
+combined="${TEST_DIR}/combined.txt"
+cat "${TEST_DIR}/stdout.txt" "${TEST_DIR}/stderr.txt" > "$combined" 2>/dev/null
+if grep -q "subA" "$combined" 2>/dev/null; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC7b: helper output references subA from .gitmodules"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC7b: helper output did not reference subA from .gitmodules")
+  echo "  FAIL: TC7b: helper output did not reference subA from .gitmodules"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# TC8: both registries present → .autoflow/sub-repos.yml takes precedence
+# .gitmodules lists "subOnlyInGitmodules" but yml lists "subOnlyInYaml" — only
+# the yaml-listed sub-repo should be visited.
+# ===========================================================================
+echo "--- TC8: yml overrides .gitmodules when both exist ---"
+setup_test_dir
+init_parent_repo
+init_sub_repo "subOnlyInYaml"
+init_sub_repo "subOnlyInGitmodules"
+mkdir -p "${TEST_DIR}/.autoflow"
+cat > "${TEST_DIR}/.autoflow/sub-repos.yml" <<'EOF'
+sub_repos:
+  - subOnlyInYaml
+EOF
+cat > "${TEST_DIR}/.gitmodules" <<'EOF'
+[submodule "subOnlyInGitmodules"]
+	path = subOnlyInGitmodules
+	url = ./subOnlyInGitmodules
+EOF
+exit_code=$(run_preflight_sync)
+assert_exit_code 0 "$exit_code" \
+  "TC8a: dual-registry exits 0"
+combined="${TEST_DIR}/combined.txt"
+cat "${TEST_DIR}/stdout.txt" "${TEST_DIR}/stderr.txt" > "$combined" 2>/dev/null
+yaml_seen=1
+gitmod_seen=1
+grep -q "subOnlyInYaml" "$combined" 2>/dev/null || yaml_seen=0
+grep -q "subOnlyInGitmodules" "$combined" 2>/dev/null || gitmod_seen=0
+if [ "$yaml_seen" -eq 1 ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC8b: helper visited subOnlyInYaml (yml entry honoured)"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC8b: helper did NOT visit subOnlyInYaml")
+  echo "  FAIL: TC8b: helper did NOT visit subOnlyInYaml"
+fi
+# TC8c is meaningful ONLY when TC8b passed (yaml entry was actually visited).
+# Otherwise "didn't visit gitmodules entry" is trivially true (e.g. helper
+# missing → no output at all). Tie the success condition together:
+#   yaml_seen=1 AND gitmod_seen=0 → precedence proven.
+if [ "$yaml_seen" -eq 1 ] && [ "$gitmod_seen" -eq 0 ]; then
+  PASS=$((PASS + 1))
+  echo "  PASS: TC8c: yml visited AND gitmodules entry skipped (precedence proven)"
+else
+  FAIL=$((FAIL + 1))
+  ERRORS+=("FAIL: TC8c: precedence not proven (yaml_seen=$yaml_seen, gitmod_seen=$gitmod_seen)")
+  echo "  FAIL: TC8c: precedence not proven (yaml_seen=$yaml_seen, gitmod_seen=$gitmod_seen)"
+fi
+cleanup_test_dir
+echo ""
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+echo "==========================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==========================="
+
+if [ ${#ERRORS[@]} -gt 0 ]; then
+  echo ""
+  echo "Failures:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - $err"
+  done
+fi
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
## Summary

Adds a conditional PREFLIGHT sub-step `0-2b` that performs multi sub-repo synchronization, generalizing the `git submodule foreach` pattern proven in `ontology-platform`. Replaces the abandoned PR #48 which only addressed a single submodule.

- **New helper** `.claude/scripts/preflight-sync` — pure bash, BSD/GNU compatible, no external deps (no `yq`, no python). Exit codes: `0` (success/skip) / `65` (registry format error) / `66` (pre-existing dirty sub-repo) / `67` (sync mid-run failure). `SYNC_FORCE=1` bypasses the dirty guard for CI.
- **Registry source**: `.autoflow/sub-repos.yml` (preferred) → `.gitmodules` (fallback). Auto-skips when both registries are empty — single-repo projects pay zero cost.
- **New `docs/design-rationale.md` Decision 12** — explains why this conditional skip is consistent with Execution Principle 1 ("Never skip phases"): _objective precondition skip_ ≠ biased "this one is simple" judgment.
- **Doc updates** propagated consistently to `CLAUDE.md`, `CLAUDE.md.template`, `docs/autoflow-guide.md`, and `subrepo-templates/_common/CLAUDE.md.template`.

## Why this design (vs the earlier PR #48 approach)

PR #48 modeled a 1:1 parent↔submodule patch flow. The actual `ontology-platform` topology is 1:N — 8 sub-repos iterated via `git submodule foreach`. This PR adopts that pattern, with `last-sync` tracking implicitly delegated to the submodule pointer (no new metadata format invented).

## Auto-Flow Trail

| Phase | Result |
|-------|--------|
| GATE:HYPOTHESIS | PASS (avg 9.33) |
| GATE:PLAN | PASS (avg 8.8) |
| GATE:QUALITY | PASS (avg 8.8, all categories ≥ 8) |

## Test plan

- [x] `bash tests/test-preflight-sync.sh` → 16/16 PASS (TC1 skip, TC2 EX_DATAERR, TC3 success path, TC4 dirty=66, TC5 sync-fail=67, TC6 SYNC_FORCE bypass, TC7 .gitmodules fallback, TC8 yml-over-gitmodules precedence)
- [x] `bash tests/test-issue-38-multi-subrepo-sync.sh` → 7/7 PASS (TC9 PREFLIGHT abort contract via combined `sync_exit==67 && phase=='PREFLIGHT'` assertion, TC10-12 doc consistency)
- [x] No regressions across the rest of the suite (`test-issue-44-revert.sh` AC8 verified — Decision number 12 preserves the post-#44 invariant)

## Follow-ups (out of scope)

1. `design-rationale.md` Decision numbering jumps 10 → 12 (post-#44 revert reserved 11). A short clarifying note could help future readers.
2. `preflight-sync` header could mention call ordering relative to `phase-set DIAGNOSE`.
3. `CLAUDE.md.template` retains a pre-existing Security/Performance category set that diverges from `CLAUDE.md`'s Consistency/Documentation — independent issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)